### PR TITLE
Fix improper package specification for pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Install the Python requirements listed in `requirements.txt`.
 ```bash
 git clone https://github.com/RedisVentures/data-loader.git
 cd redisvl
-pip install -e .
+pip install .
 ```
 
 ### Creating Input Data

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # function to read in requirements.txt to into a python list
 def read_requirements():
@@ -19,7 +19,7 @@ setup(
     python_requires=">=3.6",
     install_requires=read_requirements(),
     extras_require={"dev": read_dev_requirements()},
-    packages=["redisvl"],
+    packages=find_packages(),
     zip_safe=False,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Use ``setuptools.find_packages()`` instead of manual package specification for a proper pip install. non-editable install works now.