### PR TITLE
LLMCache

### DIFF
--- a/redisvl/llmcache/base.py
+++ b/redisvl/llmcache/base.py
@@ -1,0 +1,45 @@
+import hashlib
+import logging
+from typing import Callable, Dict, Optional
+
+
+class BaseLLMCache:
+
+    verbose: bool = True
+
+    def check(self, prompt: str) -> Optional[Dict[str, str]]:
+        raise NotImplementedError
+
+    def store(
+        self,
+        prompt: str,
+        response: str,
+        metadata: Optional[dict] = {},
+        key: Optional[str] = None,
+    ):
+        """Stores the specified key-value pair in the cache along with metadata."""
+        raise NotImplementedError
+
+    def _refresh_ttl(self, key: str):
+        """Refreshes the TTL for the specified key."""
+        raise NotImplementedError
+
+    def hash_input(self, prompt: str):
+        """Hashes the input using SHA256."""
+        return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    def cache_response(self, llm_callable: Callable):
+        """Decorator method for wrapping custom callables"""
+
+        def wrapper(*args, **kwargs):
+            # Check LLM Cache first
+            key = self.hash_input(*args, **kwargs)
+            response = self.check(*args, **kwargs)
+            if response:
+                self._refresh_ttl(key)
+                return response
+            # Otherwise execute the llm callable here
+            response = llm_callable(*args, **kwargs)
+            return response
+
+        return wrapper

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -1,0 +1,130 @@
+import logging
+import math
+import os
+from typing import Any, Callable, Dict, List, Optional
+
+from redis.commands.search.field import VectorField
+
+from redisvl.index import SearchIndex
+from redisvl.llmcache.base import BaseLLMCache
+from redisvl.providers import HuggingfaceProvider
+from redisvl.providers.base import BaseProvider
+from redisvl.query import create_vector_query
+from redisvl.utils.log import get_logger
+from redisvl.utils.utils import array_to_buffer
+
+_logger = get_logger(__name__)
+
+
+class SemanticCache(BaseLLMCache):
+    """Cache for Large Language Models."""
+
+    _default_fields = [
+        VectorField(
+            "prompt_vector",
+            "FLAT",
+            {"DIM": 768, "TYPE": "FLOAT32", "DISTANCE_METRIC": "COSINE"},
+        ),
+    ]
+    _default_provider = HuggingfaceProvider("sentence-transformers/all-mpnet-base-v2")
+
+    def __init__(
+        self,
+        index_name: str = "cache",
+        prefix: str = "llmcache",
+        threshold: float = 0.9,
+        provider: Optional[BaseProvider] = None,
+        redis_url: Optional[str] = "redis://localhost:6379",
+        connection_args: Optional[dict] = None,
+        ttl: Optional[int] = None,
+    ):
+
+        self.ttl = ttl
+        self._provider = provider or self._default_provider
+        self._threshold = threshold
+
+        # TODO - configure logging based on verbosity
+        self._index = SearchIndex(
+            index_name, prefix=prefix, fields=self._default_fields
+        )
+        connection_args = connection_args or {}
+        self._index.connect(redis_url=redis_url, **connection_args)
+        self._index.create()
+
+    @property
+    def index(self) -> SearchIndex:
+        """Returns the index for the cache."""
+        return self._index
+
+    @property
+    def threshold(self) -> float:
+        """Returns the threshold for the cache."""
+        return self._threshold
+
+    def set_threshold(self, threshold: float):
+        """Sets the threshold for the cache."""
+        self._threshold = threshold
+
+    def check(
+        self,
+        prompt: str = None,
+        vector: List[float] = None,
+        results: int = 1,
+        fields: List[str] = ["response"],
+    ) -> Optional[Dict[str, str]]:
+        """Checks whether the cache contains the specified key."""
+        if not prompt and not vector:
+            raise ValueError("Either prompt or vector must be specified.")
+
+        query = create_vector_query(
+            return_fields=fields,
+            vector_field_name="prompt_vector",
+            number_of_results=results,
+        )
+        if vector:
+            prompt_vector = array_to_buffer(vector)
+        else:
+            prompt_vector = array_to_buffer(self._provider.embed(prompt))
+        results = self._index.search(query, query_params={"vector": prompt_vector})
+
+        cache_hits = []
+        for doc in results.docs:
+            sim = similarity(doc.vector_score)
+            _logger.info("Similarity: %s", sim)
+            if similarity(doc.vector_score) > self.threshold:
+                cache_hits.append(doc.response)
+        return cache_hits
+
+    def store(
+        self,
+        prompt: str,
+        response: str,
+        vector: Optional[List[float]] = None,
+        metadata: Optional[dict] = {},
+        key: Optional[str] = None,
+    ) -> None:
+        """Stores the specified key-value pair in the cache along with metadata."""
+        if not key:
+            key = self.hash_input(prompt)
+        if vector:
+            prompt_vector = array_to_buffer(vector)
+        else:
+            prompt_vector = array_to_buffer(self._provider.embed(prompt))
+
+        payload = {"id": key, "prompt_vector": prompt_vector, "response": response}
+        payload.update(metadata)
+        self._index.load([payload])
+
+    def _refresh_ttl(self, key: str):
+        """Refreshes the TTL for the specified key."""
+        self._cache.expire(key, self.ttl)
+
+    def _delete(self, key: str):
+        self._cache.delete(key)
+
+    def _clear(self):
+        self._cache.flushdb()
+
+
+def similarity(distance):
+    return 1 - float(distance)

--- a/redisvl/providers/huggingface.py
+++ b/redisvl/providers/huggingface.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional
 
-from sentence_transformers import SentenceTransformer
 
 from redisvl.providers.base import BaseProvider
 
@@ -10,6 +9,13 @@ class HuggingfaceProvider(BaseProvider):
         # TODO set dims based on model
         dims = 768
         super().__init__(model, dims, api_config)
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            raise ImportError(
+                "Huggingface provider requires sentence-transformers library. Please install with pip install sentence-transformers"
+            )
+
         self._model_client = SentenceTransformer(model)
 
     def embed(self, emb_input: str, preprocess: callable = None) -> List[float]:

--- a/redisvl/providers/openai.py
+++ b/redisvl/providers/openai.py
@@ -1,7 +1,5 @@
 from typing import Dict, List, Optional
 
-import openai
-
 from redisvl.providers.base import BaseProvider
 
 
@@ -11,7 +9,12 @@ class OpenAIProvider(BaseProvider):
         super().__init__(model, dims, api_config)
         if not api_config:
             raise ValueError("OpenAI API key is required in api_config")
-
+        try:
+            import openai
+        except ImportError:
+            raise ImportError(
+                "OpenAI provider requires openai library. Please install with pip install openai"
+            )
         openai.api_key = api_config.get("api_key", None)
         self._model_client = openai.Embedding
 

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -1,0 +1,47 @@
+import pytest
+from redisvl.providers import HuggingfaceProvider
+from redisvl.llmcache.semantic import SemanticCache
+
+@pytest.fixture
+def provider():
+    return HuggingfaceProvider('sentence-transformers/all-mpnet-base-v2')
+
+@pytest.fixture
+def cache(provider):
+    return SemanticCache(provider=provider, threshold=0.8)
+
+@pytest.fixture
+def vector(provider):
+    return provider.embed("This is a test sentence.")
+
+def test_store_and_check(cache, vector):
+    # Check that we can store and retrieve a response
+    prompt = 'This is a test prompt.'
+    response = 'This is a test response.'
+    cache.store(prompt, response, vector=vector)
+    check_result = cache.check(vector=vector)
+    assert len(check_result) >= 1
+    assert response in check_result
+    cache.index.delete(drop=True)
+
+def test_check_no_match(cache, vector):
+    # Check behavior when there is no match in the cache
+    # In this case, we're using a vector, but the cache is empty
+    check_result = cache.check(vector=vector)
+    assert len(check_result) == 0
+    cache.index.delete(drop=True)
+
+def test_store_with_vector_and_metadata(cache, vector):
+    # Test storing a response with a vector and metadata
+    prompt = 'This is another test prompt.'
+    response = 'This is another test response.'
+    metadata = {'source': 'test'}
+    cache.store(prompt, response, vector=vector, metadata=metadata)
+    cache.index.delete(drop=True)
+
+def test_set_threshold(cache):
+    # Test the getter and setter for the threshold
+    assert cache.threshold == 0.8
+    cache.set_threshold(0.9)
+    assert cache.threshold == 0.9
+    cache.index.delete(drop=True)


### PR DESCRIPTION
Introduce ``LLMCache`` library api. This allows users to use a semantic cache in their applications through utilizing Redisvl.

example:

```python

from redisvl.llmcache.semantic import SemanticCache
cache = SemanticCache(redis_host="localhost", redis_port=6379, redis_password=None)

def answer_question(question: str):
    results = cache.check(question)
    if results:
        return results[0]
    else:
        answer = ask_gpt3(question)
        cache.store(question, answer)
        return answer

```