### PR TITLE
Llmcache ttl configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ cache.store("What is the capital of France?", "Paris")
 cache.check("What is the capital of France?")
 ["Paris"]
 
-# Cache will return the result if the query is similar enough
-cache.get("What really is the capital of France?")
+# Cache will still return the result if the query is similar enough
+cache.check("What really is the capital of France?")
 ["Paris"]
 ```
 

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -261,10 +261,14 @@ class SearchIndex(SearchIndexBase):
                 if not isinstance(data[0], dict):
                     raise TypeError("data must be an iterable of dictionaries")
 
+            # Check if outer interface passes in TTL on load
+            ttl = kwargs.get("ttl")
             pipe = self._redis_conn.pipeline(transaction=False)
             for record in data:
                 key = f"{self._prefix}:{self._get_key_field(record)}"
                 pipe.hset(key, mapping=record)  # type: ignore
+                if ttl:
+                    pipe.expire(key, ttl)
             pipe.execute()
 
     @check_connected("_redis_conn")

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -254,9 +254,8 @@ class SearchIndex(SearchIndexBase):
                 containing the data to be indexed
         raises:
             redis.exceptions.ResponseError: If the index does not exist
-
-        # TODO -- should we return a count of the upserts? or some kind of metadata?
         """
+        # TODO -- should we return a count of the upserts? or some kind of metadata?
         if data:
             if not isinstance(data, Iterable):
                 if not isinstance(data[0], dict):

--- a/redisvl/llmcache/base.py
+++ b/redisvl/llmcache/base.py
@@ -5,6 +5,10 @@ from typing import Callable, List, Optional
 class BaseLLMCache:
     verbose: bool = True
 
+    def clear(self):
+        """Clear the LLMCache and create a new underlying index."""
+        raise NotImplementedError
+
     def check(self, prompt: str) -> Optional[List[str]]:
         raise NotImplementedError
 

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -182,12 +182,10 @@ class SemanticCache(BaseLLMCache):
         if not key:
             key = self.hash_input(prompt)
 
-        if vector:
-            vector = array_to_buffer(vector)
-        else:
+        if not vector:
             vector = self._provider.embed(prompt)  # type: ignore
 
-        payload = {"id": key, "prompt_vector": vector, "response": response}
+        payload = {"id": key, "prompt_vector": array_to_buffer(vector), "response": response}
         if metadata:
             payload.update(metadata)
         self._index.load([payload])

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -116,7 +116,7 @@ class SemanticCache(BaseLLMCache):
 
     def clear(self):
         """Clear the LLMCache and create a new underlying index."""
-        self._index.create(overwrite=True)
+        self._index.delete(drop=True)
 
     def check(
         self,

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -204,8 +204,9 @@ class SemanticCache(BaseLLMCache):
     def _refresh_ttl(self, key: str):
         """Refreshes the TTL for the specified key."""
         client = self._index.client
-        if client and self.ttl:
-            client.expire(key, self.ttl)
+        if client:
+            if self.ttl:
+                client.expire(key, self.ttl)
         else:
             raise RuntimeError("LLMCache is not connected to a Redis instance.")
 

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -114,6 +114,10 @@ class SemanticCache(BaseLLMCache):
             raise ValueError("Threshold must be between 0 and 1.")
         self._threshold = float(threshold)
 
+    def clear(self):
+        """Clear the LLMCache and create a new underlying index."""
+        self._index.create(overwrite=True)
+
     def check(
         self,
         prompt: Optional[str] = None,

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -195,9 +195,8 @@ class SemanticCache(BaseLLMCache):
     def _refresh_ttl(self, key: str):
         """Refreshes the TTL for the specified key."""
         client = self._index.client
-        if client:
-            if self.ttl:
-                client.expire(key, self.ttl)
+        if client and self.ttl:
+            client.expire(key, self.ttl)
         else:
             raise RuntimeError("LLMCache is not connected to a Redis instance.")
 

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -153,9 +153,9 @@ class SemanticCache(BaseLLMCache):
 
         cache_hits = []
         for doc in results.docs:
-            self._refresh_ttl(doc.id)
             sim = similarity(doc.vector_distance)
             if sim > self.threshold:
+                self._refresh_ttl(doc.id)
                 cache_hits.append(doc.response)
         return cache_hits
 

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -179,16 +179,23 @@ class SemanticCache(BaseLLMCache):
         Raises:
             ValueError: If neither prompt nor vector is specified.
         """
+        # Prepare LLMCache inputs
         if not key:
             key = self.hash_input(prompt)
 
         if not vector:
             vector = self._provider.embed(prompt)  # type: ignore
 
-        payload = {"id": key, "prompt_vector": array_to_buffer(vector), "response": response}
+        payload = {
+            "id": key,
+            "prompt_vector": array_to_buffer(vector),
+            "response": response
+        }
         if metadata:
             payload.update(metadata)
-        self._index.load([payload])
+
+        # Load LLMCache entry with TTL
+        self._index.load([payload], ttl=self._ttl)
 
     def _refresh_ttl(self, key: str):
         """Refreshes the TTL for the specified key."""

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -1,5 +1,6 @@
 import pytest
 
+from time import sleep
 from redisvl.llmcache.semantic import SemanticCache
 from redisvl.providers import HuggingfaceProvider
 
@@ -8,11 +9,13 @@ from redisvl.providers import HuggingfaceProvider
 def provider():
     return HuggingfaceProvider("sentence-transformers/all-mpnet-base-v2")
 
-
 @pytest.fixture
 def cache(provider):
     return SemanticCache(provider=provider, threshold=0.8)
 
+@pytest.fixture
+def cache_with_ttl(provider):
+    return SemanticCache(provider=provider, threshold=0.8, ttl=2)
 
 @pytest.fixture
 def vector(provider):
@@ -27,16 +30,24 @@ def test_store_and_check(cache, vector):
     check_result = cache.check(vector=vector)
     assert len(check_result) >= 1
     assert response in check_result
-    cache.index.delete(drop=True)
+    cache.clear()
 
+def test_ttl(cache_with_ttl, vector):
+    # Check that TTL expiration kicks in after 2 seconds
+    prompt = "This is a test prompt."
+    response = "This is a test response."
+    cache_with_ttl.store(prompt, response, vector=vector)
+    sleep(3)
+    check_result = cache_with_ttl.check(vector=vector)
+    assert len(check_result) == 0
+    cache_with_ttl.clear()
 
 def test_check_no_match(cache, vector):
     # Check behavior when there is no match in the cache
     # In this case, we're using a vector, but the cache is empty
     check_result = cache.check(vector=vector)
     assert len(check_result) == 0
-    cache.index.delete(drop=True)
-
+    cache.clear()
 
 def test_store_with_vector_and_metadata(cache, vector):
     # Test storing a response with a vector and metadata
@@ -44,12 +55,26 @@ def test_store_with_vector_and_metadata(cache, vector):
     response = "This is another test response."
     metadata = {"source": "test"}
     cache.store(prompt, response, vector=vector, metadata=metadata)
-    cache.index.delete(drop=True)
-
+    check_result = cache.check(vector=vector)
+    assert len(check_result) >= 1
+    assert response in check_result
+    cache.clear()
 
 def test_set_threshold(cache):
     # Test the getter and setter for the threshold
     assert cache.threshold == 0.8
     cache.set_threshold(0.9)
     assert cache.threshold == 0.9
-    cache.index.delete(drop=True)
+    cache.clear()
+
+def test_from_existing(cache, vector, provider):
+    prompt = "This is another test prompt."
+    response = "This is another test response."
+    metadata = {"source": "test"}
+    cache.store(prompt, response, vector=vector, metadata=metadata)
+    # connect from existing?
+    new_cache = SemanticCache(provider=provider, threshold=0.8)
+    check_result = new_cache.check(vector=vector)
+    assert len(check_result) >= 1
+    assert response in check_result
+    new_cache.clear()

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -22,7 +22,7 @@ def vector(provider):
     return provider.embed("This is a test sentence.")
 
 
-def test_store_and_check(cache, vector):
+def test_store_and_check_and_clear(cache, vector):
     # Check that we can store and retrieve a response
     prompt = "This is a test prompt."
     response = "This is a test response."
@@ -31,6 +31,9 @@ def test_store_and_check(cache, vector):
     assert len(check_result) >= 1
     assert response in check_result
     cache.clear()
+    check_result = cache.check(vector=vector)
+    assert len(check_result) == 0
+    cache._index.delete(True)
 
 def test_ttl(cache_with_ttl, vector):
     # Check that TTL expiration kicks in after 2 seconds
@@ -40,14 +43,14 @@ def test_ttl(cache_with_ttl, vector):
     sleep(3)
     check_result = cache_with_ttl.check(vector=vector)
     assert len(check_result) == 0
-    cache_with_ttl.clear()
+    cache_with_ttl._index.delete(True)
 
 def test_check_no_match(cache, vector):
     # Check behavior when there is no match in the cache
     # In this case, we're using a vector, but the cache is empty
     check_result = cache.check(vector=vector)
     assert len(check_result) == 0
-    cache.clear()
+    cache._index.delete(True)
 
 def test_store_with_vector_and_metadata(cache, vector):
     # Test storing a response with a vector and metadata
@@ -58,14 +61,14 @@ def test_store_with_vector_and_metadata(cache, vector):
     check_result = cache.check(vector=vector)
     assert len(check_result) >= 1
     assert response in check_result
-    cache.clear()
+    cache._index.delete(True)
 
 def test_set_threshold(cache):
     # Test the getter and setter for the threshold
     assert cache.threshold == 0.8
     cache.set_threshold(0.9)
     assert cache.threshold == 0.9
-    cache.clear()
+    cache._index.delete(True)
 
 def test_from_existing(cache, vector, provider):
     prompt = "This is another test prompt."
@@ -77,4 +80,4 @@ def test_from_existing(cache, vector, provider):
     check_result = new_cache.check(vector=vector)
     assert len(check_result) >= 1
     assert response in check_result
-    new_cache.clear()
+    new_cache._index.delete(True)


### PR DESCRIPTION
Enables TTL for loading data to Redis using RedisVL. This TTL is an optional kwarg for the underlying `load` function. This is particularly useful for clients and abstractions like SemanticCache that lean on Redis support for ephemeral data.

Also adds a `clear` method to the LLM cache class that invalidates all data from the cache, but does not disturb the index itself.