### PR TITLE
Add optional vectorizer bytes conversion and exponential backoff

### DIFF
--- a/docs/examples/openai_qna.ipynb
+++ b/docs/examples/openai_qna.ipynb
@@ -710,13 +710,11 @@
    "source": [
     "import os\n",
     "from redisvl.vectorize.text import OpenAITextVectorizer\n",
-    "from redisvl.utils.utils import array_to_buffer\n",
     "\n",
     "api_key = os.environ.get(\"OPENAI_API_KEY\", \"\")\n",
     "oaip = OpenAITextVectorizer(EMBEDDINGS_MODEL, api_config={\"api_key\": api_key})\n",
     "\n",
-    "chunked_data[\"embedding\"] = oaip.embed_many(chunked_data[\"content\"].tolist())\n",
-    "chunked_data[\"embedding\"] = chunked_data[\"embedding\"].apply(lambda x: array_to_buffer(x))\n",
+    "chunked_data[\"embedding\"] = oaip.embed_many(chunked_data[\"content\"].tolist(), as_buffer=True)\n",
     "chunked_data"
    ]
   },

--- a/docs/user_guide/vectorizers_03.ipynb
+++ b/docs/user_guide/vectorizers_03.ipynb
@@ -105,7 +105,7 @@
     "    \"Today is a sunny day\"\n",
     "]\n",
     "\n",
-    "embeddings = hf.embed_many(sentences)\n"
+    "embeddings = hf.embed_many(sentences, as_buffer=True)\n"
    ]
   },
   {
@@ -183,7 +183,7 @@
     "# the vector is stored as a bytes buffer\n",
     "\n",
     "data = [{\"text\": t,\n",
-    "         \"embedding\": array_to_buffer(v)}\n",
+    "         \"embedding\": v}\n",
     "        for t, v in zip(sentences, embeddings)]\n",
     "\n",
     "index.load(data)"

--- a/redisvl/vectorize/base.py
+++ b/redisvl/vectorize/base.py
@@ -21,27 +21,35 @@ class BaseVectorizer:
 
     def embed_many(
         self,
-        inputs: List[str],
+        texts: List[str],
         preprocess: Optional[Callable] = None,
-        chunk_size: int = 1000,
+        batch_size: Optional[int] = 1000,
+        as_buffer: Optional[bool] = False
     ) -> List[List[float]]:
         raise NotImplementedError
 
     def embed(
-        self, emb_input: str, preprocess: Optional[Callable] = None
+        self,
+        text: str,
+        preprocess: Optional[Callable] = None,
+        as_buffer: Optional[bool] = False
     ) -> List[float]:
         raise NotImplementedError
 
     async def aembed_many(
         self,
-        inputs: List[str],
+        texts: List[str],
         preprocess: Optional[Callable] = None,
-        chunk_size: int = 1000,
+        batch_size: Optional[int] = 1000,
+        as_buffer: Optional[bool] = False
     ) -> List[List[float]]:
         raise NotImplementedError
 
     async def aembed(
-        self, emb_input: str, preprocess: Optional[Callable] = None
+        self,
+        text: str,
+        preprocess: Optional[Callable] = None,
+        as_buffer: Optional[bool] = False
     ) -> List[float]:
         raise NotImplementedError
 

--- a/redisvl/vectorize/base.py
+++ b/redisvl/vectorize/base.py
@@ -1,5 +1,5 @@
 from typing import Callable, Dict, List, Optional
-
+from redisvl.utils.utils import array_to_buffer
 
 class BaseVectorizer:
     def __init__(self, model: str, dims: int, api_config: Optional[Dict] = None):
@@ -51,3 +51,8 @@ class BaseVectorizer:
                 yield [preprocess(chunk) for chunk in seq[pos : pos + size]]
             else:
                 yield seq[pos : pos + size]
+
+    def _process_embedding(self, embedding: List[float], as_buffer: bool):
+        if as_buffer:
+            return array_to_buffer(embedding)
+        return embedding

--- a/redisvl/vectorize/base.py
+++ b/redisvl/vectorize/base.py
@@ -1,5 +1,7 @@
 from typing import Callable, Dict, List, Optional
+
 from redisvl.utils.utils import array_to_buffer
+
 
 class BaseVectorizer:
     def __init__(self, model: str, dims: int, api_config: Optional[Dict] = None):
@@ -24,7 +26,7 @@ class BaseVectorizer:
         texts: List[str],
         preprocess: Optional[Callable] = None,
         batch_size: Optional[int] = 1000,
-        as_buffer: Optional[bool] = False
+        as_buffer: Optional[bool] = False,
     ) -> List[List[float]]:
         raise NotImplementedError
 
@@ -32,7 +34,7 @@ class BaseVectorizer:
         self,
         text: str,
         preprocess: Optional[Callable] = None,
-        as_buffer: Optional[bool] = False
+        as_buffer: Optional[bool] = False,
     ) -> List[float]:
         raise NotImplementedError
 
@@ -41,7 +43,7 @@ class BaseVectorizer:
         texts: List[str],
         preprocess: Optional[Callable] = None,
         batch_size: Optional[int] = 1000,
-        as_buffer: Optional[bool] = False
+        as_buffer: Optional[bool] = False,
     ) -> List[List[float]]:
         raise NotImplementedError
 
@@ -49,7 +51,7 @@ class BaseVectorizer:
         self,
         text: str,
         preprocess: Optional[Callable] = None,
-        as_buffer: Optional[bool] = False
+        as_buffer: Optional[bool] = False,
     ) -> List[float]:
         raise NotImplementedError
 

--- a/redisvl/vectorize/text/huggingface.py
+++ b/redisvl/vectorize/text/huggingface.py
@@ -22,7 +22,7 @@ class HFTextVectorizer(BaseVectorizer):
         self,
         text: str,
         preprocess: Optional[Callable] = None,
-        as_buffer: Optional[float] = False
+        as_buffer: Optional[float] = False,
     ) -> List[float]:
         """Embed a chunk of text using the Hugging Face sentence transformer.
 
@@ -46,7 +46,7 @@ class HFTextVectorizer(BaseVectorizer):
         texts: List[str],
         preprocess: Optional[Callable] = None,
         batch_size: int = 1000,
-        as_buffer: Optional[float] = None
+        as_buffer: Optional[float] = None,
     ) -> List[List[float]]:
         """Asynchronously embed many chunks of texts using the Hugging Face sentence
         transformer.
@@ -66,7 +66,10 @@ class HFTextVectorizer(BaseVectorizer):
         embeddings: List = []
         for batch in self.batchify(texts, batch_size, preprocess):
             batch_embeddings = self._model_client.encode(batch)
-            embeddings.extend([
-                self._process_embedding(embedding.tolist(), as_buffer) for embedding in batch_embeddings
-            ])
+            embeddings.extend(
+                [
+                    self._process_embedding(embedding.tolist(), as_buffer)
+                    for embedding in batch_embeddings
+                ]
+            )
         return embeddings

--- a/redisvl/vectorize/text/huggingface.py
+++ b/redisvl/vectorize/text/huggingface.py
@@ -1,6 +1,7 @@
 from typing import Callable, Dict, List, Optional
 
 from redisvl.vectorize.base import BaseVectorizer
+from redisvl.utils.utils import array_to_buffer
 
 
 class HFTextVectorizer(BaseVectorizer):
@@ -18,21 +19,31 @@ class HFTextVectorizer(BaseVectorizer):
         self._model_client = SentenceTransformer(model)
 
     def embed(
-        self, emb_input: str, preprocess: Optional[Callable] = None
+        self,
+        emb_input: str,
+        preprocess: Optional[Callable] = None,
+        as_buffer: Optional[bool] = False
     ) -> List[float]:
         if preprocess:
             emb_input = preprocess(emb_input)
         embedding = self._model_client.encode([emb_input])[0]
-        return embedding.tolist()
+        embedding = embedding.tolist()
+        if as_buffer:
+            return array_to_buffer(embedding)
+        return embedding
 
     def embed_many(
         self,
         inputs: List[str],
         preprocess: Optional[Callable] = None,
         chunk_size: int = 1000,
+        as_buffer: Optional[float] = None
     ) -> List[List[float]]:
         embeddings = []
         for batch in self.batchify(inputs, chunk_size, preprocess):
             batch_embeddings = self._model_client.encode(batch)
-            embeddings.extend([embedding.tolist() for embedding in batch_embeddings])
+            embeddings.extend([
+                array_to_buffer(embedding.tolist()) if as_buffer else embedding.tolist()
+                for embedding in batch_embeddings
+            ])
         return embeddings

--- a/redisvl/vectorize/text/openai.py
+++ b/redisvl/vectorize/text/openai.py
@@ -1,9 +1,10 @@
 from typing import Callable, Dict, List, Optional
-from tenacity import (
+
+from tenacity import (  # for exponential backoff
     retry,
     stop_after_attempt,
     wait_random_exponential,
-)  # for exponential backoff
+)
 
 from redisvl.vectorize.base import BaseVectorizer
 
@@ -30,7 +31,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         texts: List[str],
         preprocess: Optional[Callable] = None,
         batch_size: Optional[int] = 10,
-        as_buffer: Optional[float] = False
+        as_buffer: Optional[float] = False,
     ) -> List[List[float]]:
         """Embed many chunks of texts using the OpenAI API.
 
@@ -50,7 +51,8 @@ class OpenAITextVectorizer(BaseVectorizer):
         for batch in self.batchify(texts, batch_size, preprocess):
             response = self._model_client.create(input=batch, engine=self._model)
             embeddings += [
-                self._process_embedding(r["embedding"], as_buffer) for r in response["data"]
+                self._process_embedding(r["embedding"], as_buffer)
+                for r in response["data"]
             ]
         return embeddings
 
@@ -59,7 +61,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         self,
         text: str,
         preprocess: Optional[Callable] = None,
-        as_buffer: Optional[float] = False
+        as_buffer: Optional[float] = False,
     ) -> List[float]:
         """Embed a chunk of text using the OpenAI API.
 
@@ -84,7 +86,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         texts: List[str],
         preprocess: Optional[Callable] = None,
         batch_size: int = 1000,
-        as_buffer: Optional[bool] = False
+        as_buffer: Optional[bool] = False,
     ) -> List[List[float]]:
         """Asynchronously embed many chunks of texts using the OpenAI API.
 
@@ -104,7 +106,8 @@ class OpenAITextVectorizer(BaseVectorizer):
         for batch in self.batchify(texts, batch_size, preprocess):
             response = await self._model_client.acreate(input=batch, engine=self._model)
             embeddings += [
-                self._process_embedding(r["embedding"], as_buffer) for r in response["data"]
+                self._process_embedding(r["embedding"], as_buffer)
+                for r in response["data"]
             ]
         return embeddings
 
@@ -113,7 +116,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         self,
         text: str,
         preprocess: Optional[Callable] = None,
-        as_buffer: Optional[bool] = False
+        as_buffer: Optional[bool] = False,
     ) -> List[float]:
         """Asynchronously embed a chunk of text using the OpenAI API.
 

--- a/redisvl/vectorize/text/openai.py
+++ b/redisvl/vectorize/text/openai.py
@@ -1,4 +1,9 @@
 from typing import Callable, Dict, List, Optional
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_random_exponential,
+)  # for exponential backoff
 
 from redisvl.vectorize.base import BaseVectorizer
 
@@ -19,6 +24,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         openai.api_key = api_config.get("api_key", None)
         self._model_client = openai.Embedding
 
+    @retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))
     def embed_many(
         self,
         texts: List[str],
@@ -48,6 +54,7 @@ class OpenAITextVectorizer(BaseVectorizer):
             ]
         return embeddings
 
+    @retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))
     def embed(
         self,
         text: str,
@@ -71,6 +78,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         result = self._model_client.create(input=[text], engine=self._model)
         return self._process_embedding(result["data"][0]["embedding"], as_buffer)
 
+    @retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))
     async def aembed_many(
         self,
         texts: List[str],
@@ -100,6 +108,7 @@ class OpenAITextVectorizer(BaseVectorizer):
             ]
         return embeddings
 
+    @retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))
     async def aembed(
         self,
         text: str,

--- a/redisvl/vectorize/text/openai.py
+++ b/redisvl/vectorize/text/openai.py
@@ -1,9 +1,10 @@
 from typing import Callable, Dict, List, Optional
 
 from redisvl.vectorize.base import BaseVectorizer
-
+from redisvl.utils.utils import array_to_buffer
 
 class OpenAITextVectorizer(BaseVectorizer):
+    # TODO - add docstring
     def __init__(self, model: str, api_config: Optional[Dict] = None):
         dims = 1536
         super().__init__(model, dims, api_config)
@@ -18,42 +19,106 @@ class OpenAITextVectorizer(BaseVectorizer):
         openai.api_key = api_config.get("api_key", None)
         self._model_client = openai.Embedding
 
+    def _process_embedding(self, embedding: List[float], as_buffer: bool):
+        if as_buffer:
+            return array_to_buffer(embedding)
+        return embedding
+
     def embed_many(
         self,
         inputs: List[str],
         preprocess: Optional[Callable] = None,
-        chunk_size: int = 1000,
+        batch_size: Optional[int] = 10,
+        as_buffer: Optional[float] = False
     ) -> List[List[float]]:
-        results = []
-        for batch in self.batchify(inputs, chunk_size, preprocess):
+        """Embed many chunks of texts using the OpenAI API.
+
+        Args:
+            inputs (List[str]): List of text chunks to embed.
+            preprocess (Optional[Callable], optional): Optional preprocessing callable to
+                perform before vectorization. Defaults to None.
+            batch_size (int, optional): Batch size of texts to use when creating embeddings. Defaults to 10.
+            as_buffer (Optional[float], optional): Whether to convert the raw embedding to a byte string. Defaults to False.
+
+        Returns:
+            List[List[float]]: _description_
+        """
+        embeddings: List = []
+        for batch in self.batchify(inputs, batch_size, preprocess):
             response = self._model_client.create(input=batch, engine=self._model)
-            results += [r["embedding"] for r in response["data"]]
-        return results
+            embeddings += [
+                self._process_embedding(r["embedding"], as_buffer) for r in response["data"]
+            ]
+        return embeddings
 
     def embed(
-        self, emb_input: str, preprocess: Optional[Callable] = None
+        self,
+        inputs: List[str],
+        preprocess: Optional[Callable] = None,
+        batch_size: Optional[int] = 10,
+        as_buffer: Optional[float] = False
     ) -> List[float]:
+        """Embed chunks of texts using the OpenAI API.
+
+        Args:
+            inputs (List[str]): List of text chunks to embed.
+            preprocess (Optional[Callable], optional): Optional preprocessing callable to
+                perform before vectorization. Defaults to None.
+            batch_size (int, optional): Batch size of texts to use when creating embeddings. Defaults to 10.
+            as_buffer (Optional[float], optional): Whether to convert the raw embedding to a byte string. Defaults to False.
+
+        Returns:
+            List[List[float]]: _description_
+        """
         if preprocess:
             emb_input = preprocess(emb_input)
         result = self._model_client.create(input=[emb_input], engine=self._model)
-        return result["data"][0]["embedding"]
+        return self._process_embedding(result["data"][0]["embedding"], as_buffer)
+
 
     async def aembed_many(
         self,
         inputs: List[str],
         preprocess: Optional[Callable] = None,
         chunk_size: int = 1000,
+        as_buffer: Optional[bool] = False
     ) -> List[List[float]]:
-        results = []
+        """_summary_
+
+        Args:
+            inputs (List[str]): _description_
+            preprocess (Optional[Callable], optional): _description_. Defaults to None.
+            chunk_size (int, optional): _description_. Defaults to 1000.
+            as_buffer (Optional[bool], optional): _description_. Defaults to False.
+
+        Returns:
+            List[List[float]]: _description_
+        """
+        embeddings: List = []
         for batch in self.batchify(inputs, chunk_size, preprocess):
             response = await self._model_client.acreate(input=batch, engine=self._model)
-            results += [r["embedding"] for r in response["data"]]
-        return results
+            embeddings += [
+                self._process_embedding(r["embedding"], as_buffer) for r in response["data"]
+            ]
+        return embeddings
 
     async def aembed(
-        self, emb_input: str, preprocess: Optional[Callable] = None
+        self,
+        emb_input: str,
+        preprocess: Optional[Callable] = None,
+        as_buffer: Optional[bool] = False
     ) -> List[float]:
+        """_summary_
+
+        Args:
+            emb_input (str): _description_
+            preprocess (Optional[Callable], optional): _description_. Defaults to None.
+            as_buffer (Optional[bool], optional): _description_. Defaults to False.
+
+        Returns:
+            List[float]: _description_
+        """
         if preprocess:
             emb_input = preprocess(emb_input)
         result = await self._model_client.acreate(input=[emb_input], engine=self._model)
-        return result["data"][0]["embedding"]
+        return self._process_embedding(result["data"][0]["embedding"], as_buffer)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ redis>=4.3.4
 pyyaml
 coloredlogs
 pydantic>=2.0.0
+tenacity==8.2.2


### PR DESCRIPTION
This PR adds support for:
- Exponential backoff for the openAI vectorizer
- Optional `as_buffer` flag that can be passed to the various vectorizer embedding creation methods. Defaults to `False` always and assumes the user wants it back as a list of floats. But now this option is enabled.