### PR TITLE
add support for processing results on search and query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ redisvl.egg-info/
 .coverage
 scratch
 .DS_Store
+*.csv

--- a/docs/examples/openai_qna.ipynb
+++ b/docs/examples/openai_qna.ipynb
@@ -40,9 +40,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: pandas in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (1.5.0)\n",
+      "Requirement already satisfied: wget in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (3.2)\n",
+      "Requirement already satisfied: tenacity in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (8.2.2)\n",
+      "Requirement already satisfied: tiktoken in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (0.4.0)\n",
+      "Requirement already satisfied: openai in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (0.27.2)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.1 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from pandas) (2.8.2)\n",
+      "Requirement already satisfied: numpy>=1.20.3 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from pandas) (1.24.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from pandas) (2022.4)\n",
+      "Requirement already satisfied: regex>=2022.1.18 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from tiktoken) (2022.9.13)\n",
+      "Requirement already satisfied: requests>=2.26.0 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from tiktoken) (2.28.1)\n",
+      "Requirement already satisfied: aiohttp in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from openai) (3.8.3)\n",
+      "Requirement already satisfied: tqdm in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from openai) (4.63.0)\n",
+      "Requirement already satisfied: six>=1.5 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from python-dateutil>=2.8.1->pandas) (1.16.0)\n",
+      "Requirement already satisfied: charset-normalizer<3,>=2 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from requests>=2.26.0->tiktoken) (2.0.4)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from requests>=2.26.0->tiktoken) (3.3)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from requests>=2.26.0->tiktoken) (1.26.8)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from requests>=2.26.0->tiktoken) (2022.9.24)\n",
+      "Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from aiohttp->openai) (4.0.2)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from aiohttp->openai) (1.3.1)\n",
+      "Requirement already satisfied: attrs>=17.3.0 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from aiohttp->openai) (22.1.0)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from aiohttp->openai) (1.3.3)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.0 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from aiohttp->openai) (1.8.2)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /Users/tyler.hutcherson/miniconda3/lib/python3.9/site-packages (from aiohttp->openai) (6.0.4)\n"
+     ]
+    }
+   ],
    "source": [
     "# first we need to install a few things\n",
     "\n",
@@ -51,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -60,7 +90,7 @@
        "'wikipedia_articles_2000.csv'"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -263,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -362,7 +392,7 @@
        "4                 0  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -383,210 +413,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>url</th>\n",
-       "      <th>title</th>\n",
-       "      <th>content</th>\n",
-       "      <th>file_chunk_index</th>\n",
-       "      <th>embedding</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Photon-!0</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Photon</td>\n",
-       "      <td>Photon</td>\n",
-       "      <td>Title: Photon;\\nPhotons  (from Greek φως, mean...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>b'\\xc2\\xf8\\xc9;\\xa7]\\xfb;\\x88\\x90P\\xbc`\\xcc\\x9...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Photon-!1</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Photon</td>\n",
-       "      <td>Photon</td>\n",
-       "      <td>Title: Photon;\\nElementary particles</td>\n",
-       "      <td>1</td>\n",
-       "      <td>b'\\x03\\x1d#\\xbc\\x00c\\x8d&lt;\\xae\\xcam\\xbc\\xc5\\x1f...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Thomas Dolby-!0</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Thomas%20Dolby</td>\n",
-       "      <td>Thomas Dolby</td>\n",
-       "      <td>Title: Thomas Dolby;\\nThomas Dolby (born Thoma...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>b'k\\xaf\\xcc\\xbc\\x89\\xe5\\xad;3\\xea\\xd8\\xbc+\\x81...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Embroidery-!0</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Embroidery</td>\n",
-       "      <td>Embroidery</td>\n",
-       "      <td>Title: Embroidery;\\nEmbroidery is the art of d...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>b'07\\xf5\\xbc\\xaf\\xcb\\x02\\xbc\\x90\\xe6N\\xbc\\x84\\...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Consecutive integer-!0</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Consecutive%...</td>\n",
-       "      <td>Consecutive integer</td>\n",
-       "      <td>Title: Consecutive integer;\\nConsecutive numbe...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>b'0(\\xfa\\xbb\\x81\\xd2\\xd9;\\xaf\\x92\\x9a;\\xd3FL\\x...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2688</th>\n",
-       "      <td>Alanis Morissette-!1</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Alanis%20Mor...</td>\n",
-       "      <td>Alanis Morissette</td>\n",
-       "      <td>Title: Alanis Morissette;\\nTwin people from Ca...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>b'\\xc1K5\\xbc\\xb8\"\\xe0\\xbc\\x17A\\x07\\xbb\\xb0\\xbc...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2689</th>\n",
-       "      <td>Brontosaurus-!0</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Brontosaurus</td>\n",
-       "      <td>Brontosaurus</td>\n",
-       "      <td>Title: Brontosaurus;\\nBrontosaurus  is a genus...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>b'\\xc6.\\xdb\\xbc\\xc1+\\xb1:\\xfcR\\x81\\xbc\\x10\\x0b...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2690</th>\n",
-       "      <td>Work (physics)-!0</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Work%20%28ph...</td>\n",
-       "      <td>Work (physics)</td>\n",
-       "      <td>Title: Work (physics);\\nIn physics, a force do...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>b'\\x97\\x82\\xb9\\xbbL\\x90d\\xbc\\xb7G\\x9c\\xba\\x94g...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2691</th>\n",
-       "      <td>Syllable-!0</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Syllable</td>\n",
-       "      <td>Syllable</td>\n",
-       "      <td>Title: Syllable;\\nA syllable is a unit of pron...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>b'\\xe4\\xa3\\x1c:\\x83g\\x90&lt;\\x99=s;*[E\\xbb\\x10 \"\\...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2692</th>\n",
-       "      <td>Syllable-!1</td>\n",
-       "      <td>https://simple.wikipedia.org/wiki/Syllable</td>\n",
-       "      <td>Syllable</td>\n",
-       "      <td>Title: Syllable;\\nGrammar</td>\n",
-       "      <td>1</td>\n",
-       "      <td>b'\\x17U+\\xbb\\xe4\\xea\\x86;;\\\\\\x9a:^\\x82\\xc6:\\x1...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>2693 rows × 6 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                          id  \\\n",
-       "0                  Photon-!0   \n",
-       "1                  Photon-!1   \n",
-       "2            Thomas Dolby-!0   \n",
-       "3              Embroidery-!0   \n",
-       "4     Consecutive integer-!0   \n",
-       "...                      ...   \n",
-       "2688    Alanis Morissette-!1   \n",
-       "2689         Brontosaurus-!0   \n",
-       "2690       Work (physics)-!0   \n",
-       "2691             Syllable-!0   \n",
-       "2692             Syllable-!1   \n",
-       "\n",
-       "                                                    url                title  \\\n",
-       "0              https://simple.wikipedia.org/wiki/Photon               Photon   \n",
-       "1              https://simple.wikipedia.org/wiki/Photon               Photon   \n",
-       "2      https://simple.wikipedia.org/wiki/Thomas%20Dolby         Thomas Dolby   \n",
-       "3          https://simple.wikipedia.org/wiki/Embroidery           Embroidery   \n",
-       "4     https://simple.wikipedia.org/wiki/Consecutive%...  Consecutive integer   \n",
-       "...                                                 ...                  ...   \n",
-       "2688  https://simple.wikipedia.org/wiki/Alanis%20Mor...    Alanis Morissette   \n",
-       "2689     https://simple.wikipedia.org/wiki/Brontosaurus         Brontosaurus   \n",
-       "2690  https://simple.wikipedia.org/wiki/Work%20%28ph...       Work (physics)   \n",
-       "2691         https://simple.wikipedia.org/wiki/Syllable             Syllable   \n",
-       "2692         https://simple.wikipedia.org/wiki/Syllable             Syllable   \n",
-       "\n",
-       "                                                content  file_chunk_index  \\\n",
-       "0     Title: Photon;\\nPhotons  (from Greek φως, mean...                 0   \n",
-       "1                  Title: Photon;\\nElementary particles                 1   \n",
-       "2     Title: Thomas Dolby;\\nThomas Dolby (born Thoma...                 0   \n",
-       "3     Title: Embroidery;\\nEmbroidery is the art of d...                 0   \n",
-       "4     Title: Consecutive integer;\\nConsecutive numbe...                 0   \n",
-       "...                                                 ...               ...   \n",
-       "2688  Title: Alanis Morissette;\\nTwin people from Ca...                 1   \n",
-       "2689  Title: Brontosaurus;\\nBrontosaurus  is a genus...                 0   \n",
-       "2690  Title: Work (physics);\\nIn physics, a force do...                 0   \n",
-       "2691  Title: Syllable;\\nA syllable is a unit of pron...                 0   \n",
-       "2692                          Title: Syllable;\\nGrammar                 1   \n",
-       "\n",
-       "                                              embedding  \n",
-       "0     b'\\xc2\\xf8\\xc9;\\xa7]\\xfb;\\x88\\x90P\\xbc`\\xcc\\x9...  \n",
-       "1     b'\\x03\\x1d#\\xbc\\x00c\\x8d<\\xae\\xcam\\xbc\\xc5\\x1f...  \n",
-       "2     b'k\\xaf\\xcc\\xbc\\x89\\xe5\\xad;3\\xea\\xd8\\xbc+\\x81...  \n",
-       "3     b'07\\xf5\\xbc\\xaf\\xcb\\x02\\xbc\\x90\\xe6N\\xbc\\x84\\...  \n",
-       "4     b'0(\\xfa\\xbb\\x81\\xd2\\xd9;\\xaf\\x92\\x9a;\\xd3FL\\x...  \n",
-       "...                                                 ...  \n",
-       "2688  b'\\xc1K5\\xbc\\xb8\"\\xe0\\xbc\\x17A\\x07\\xbb\\xb0\\xbc...  \n",
-       "2689  b'\\xc6.\\xdb\\xbc\\xc1+\\xb1:\\xfcR\\x81\\xbc\\x10\\x0b...  \n",
-       "2690  b'\\x97\\x82\\xb9\\xbbL\\x90d\\xbc\\xb7G\\x9c\\xba\\x94g...  \n",
-       "2691  b'\\xe4\\xa3\\x1c:\\x83g\\x90<\\x99=s;*[E\\xbb\\x10 \"\\...  \n",
-       "2692  b'\\x17U+\\xbb\\xe4\\xea\\x86;;\\\\\\x9a:^\\x82\\xc6:\\x1...  \n",
-       "\n",
-       "[2693 rows x 6 columns]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import getpass\n",
     "from redisvl.vectorize.text import OpenAITextVectorizer\n",
     "\n",
-    "api_key = getpass.getpass(\"Enter your OpenAI API key: \")\n",
+    "api_key = os.getenv(\"OPENAI_API_KEY\") or getpass.getpass(\"Enter your OpenAI API key: \")\n",
     "oaip = OpenAITextVectorizer(EMBEDDINGS_MODEL, api_config={\"api_key\": api_key})\n",
     "\n",
     "chunked_data[\"embedding\"] = oaip.embed_many(chunked_data[\"content\"].tolist(), as_buffer=True)\n",
@@ -637,7 +472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -651,15 +486,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m18:51:29\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   Indices:\n",
-      "\u001b[32m18:51:29\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   1. wiki\n"
+      "\u001b[32m14:48:22\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   Indices:\n",
+      "\u001b[32m14:48:22\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   1. wiki\n"
      ]
     }
    ],
@@ -669,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -701,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -724,7 +559,7 @@
     "    return retrieval_prompt\n",
     "\n",
     "async def retrieve_context(query):\n",
-    "      # Embed the query\n",
+    "    # Embed the query\n",
     "    query_embedding = oaip.embed(query)\n",
     "\n",
     "    # Get the top result from the index\n",
@@ -737,13 +572,11 @@
     "\n",
     "    results = await index.query(vector_query)\n",
     "    content = \"\"\n",
-    "    if len(results.docs) > 1:\n",
-    "        content = results.docs[0][\"content\"]\n",
+    "    if len(results) > 1:\n",
+    "        content = results[0][\"content\"]\n",
     "    return content\n",
     "\n",
-    "\n",
     "async def answer_question(query):\n",
-    "\n",
     "    # Retrieve the context\n",
     "    content = await retrieve_context(query)\n",
     "\n",
@@ -760,23 +593,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['A Brontosaurus, also known as Apatosaurus, is a long-necked dinosaur that lived',\n",
-       " 'during the Late Jurassic period, approximately 150 million years ago. It was one',\n",
-       " 'of the largest land animals that ever existed, measuring up to 75 feet in length',\n",
-       " 'and weighing around 25 tons. Brontosaurus had a small head, a long neck, a',\n",
-       " 'powerful tail, and a relatively thin and tall body. They were herbivorous and',\n",
-       " 'likely lived in herds, feeding on plants and vegetation. In recent years, there',\n",
-       " 'has been some debate and reclassification of the Brontosaurus species, but it',\n",
-       " 'remains an iconic and well-known dinosaur.']"
+       "['A Brontosaurus is a large, herbivorous dinosaur that lived during the Late',\n",
+       " 'Jurassic period. It is known for its long neck and tail, as well as its massive',\n",
+       " 'size. The Brontosaurus is part of the sauropod family of dinosaurs and is often',\n",
+       " 'depicted as peacefully grazing on vegetation. However, it is important to note',\n",
+       " 'that the Brontosaurus was once thought to have been the same as the Apatosaurus,',\n",
+       " 'but recent research has indicated that they are two distinct species.']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -790,16 +621,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'I\\'m sorry, but there is no content available to answer your question about a \"trackiosamidon.\"'"
+       "\"I don't know.\""
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -812,35 +643,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "['Alanis Morissette is a Canadian-American singer, songwriter, and',\n",
-       " 'actress. She gained fame in the 1990s as one of the leading voices of',\n",
-       " 'the alternative rock movement. Born on June 1, 1974, in Ottawa,',\n",
-       " 'Canada, Morissette started her music career at a young age and',\n",
-       " 'released her first studio album, \"Alanis,\" in 1991. However, it was',\n",
-       " 'her third album, \"Jagged Little Pill,\" released in 1995, that',\n",
-       " 'catapulted her to international success. The album spawned hit singles',\n",
-       " 'like \"You Oughta Know,\" \"Hand in My Pocket,\" and \"Ironic.\"  Throughout',\n",
-       " 'her career, Morissette has continued to release successful albums and',\n",
-       " 'has received numerous accolades, including several Grammy Awards. In',\n",
-       " 'addition to her music, she has also ventured into acting and appeared',\n",
-       " 'in films and television shows such as \"Dogma\" and \"Weeds.\"',\n",
-       " \"Morissette's personal life has also been in the public eye. She has\",\n",
-       " 'been open about her struggles with depression, anxiety, and eating',\n",
-       " 'disorders. In recent years, she has become an advocate for mental',\n",
-       " 'health and has been actively involved in raising awareness and',\n",
-       " 'reducing the stigma surrounding mental health issues.  Overall, Alanis',\n",
-       " \"Morissette's life has been filled with musical accomplishments,\",\n",
-       " 'personal challenges, and a dedication to promoting mental health',\n",
-       " 'awareness.']"
+       " 'actress. She rose to fame in the 1990s with her album \"Jagged Little',\n",
+       " 'Pill,\" which became a major hit and earned her several Grammy Awards,',\n",
+       " 'including Album of the Year. Morissette is known for her introspective',\n",
+       " 'and confessional songwriting style, often addressing themes of love,',\n",
+       " 'relationships, and personal struggles in her music. Apart from her',\n",
+       " 'successful music career, she has also ventured into acting and has',\n",
+       " 'appeared in various films and TV shows. Overall, Alanis Morissette has',\n",
+       " 'had a significant impact on the music industry and continues to',\n",
+       " 'inspire fans with her powerful and emotional performances.']"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -861,7 +682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,29 +693,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
-    "async def retrieve_context(query):\n",
-    "      # Embed the query\n",
-    "    query_embedding = oaip.embed(query)\n",
-    "\n",
-    "    # Get the top result from the index\n",
-    "    vector_query = VectorQuery(\n",
-    "        vector=query_embedding,\n",
-    "        vector_field_name=\"embedding\",\n",
-    "        return_fields=[\"content\"],\n",
-    "        num_results=1\n",
-    "    )\n",
-    "\n",
-    "    results = await index.query(vector_query)\n",
-    "    content = \"\"\n",
-    "    if len(results.docs) > 1:\n",
-    "        content = results.docs[0][\"content\"]\n",
-    "    return content\n",
-    "\n",
-    "\n",
     "async def answer_question(query):\n",
     "\n",
     "    # check the cache\n",
@@ -922,14 +724,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken: 12.143998861312866\n",
+      "Time taken: 11.857624769210815\n",
       "\n"
      ]
     },
@@ -937,28 +739,22 @@
      "data": {
       "text/plain": [
        "['Alanis Morissette is a Canadian-American singer, songwriter, and actress. She',\n",
-       " 'was born on June 1, 1974, in Ottawa, Ontario, Canada. Morissette began her music',\n",
-       " 'career at a young age, signing a record deal at the age of 14. She gained',\n",
-       " 'international fame with her third studio album, \"Jagged Little Pill,\" released',\n",
-       " 'in 1995. The album was a huge success, selling millions of copies worldwide and',\n",
-       " 'earning her multiple awards, including four Grammy Awards.  Throughout her',\n",
-       " 'career, Morissette has released several successful albums and singles, covering',\n",
-       " 'a variety of genres like alternative rock, pop, and folk. Some of her popular',\n",
-       " 'songs include \"Ironic,\" \"You Oughta Know,\" and \"Hand in My Pocket.\"  Apart from',\n",
-       " 'her music career, Alanis Morissette has also appeared in movies and television',\n",
-       " 'shows. She made her acting debut in the film \"Dogma\" in 1999 and has since',\n",
-       " 'appeared in films like \"Jay and Silent Bob Strike Back\" and \"Weeds.\"  In',\n",
-       " 'addition to her artistic pursuits, Morissette is known for her activism and',\n",
-       " 'advocacy work. She is an advocate for mental health awareness and has spoken',\n",
-       " 'openly about her experiences with depression and eating disorders. Morissette',\n",
-       " 'has also been involved in various charitable initiatives and supported',\n",
-       " 'organizations like Amnesty International and the David Lynch Foundation.',\n",
-       " 'Overall, Alanis Morissette has had a successful and impactful career in the',\n",
-       " 'music industry, becoming one of the most prominent female artists of her',\n",
-       " 'generation. She continues to create music, perform, and engage in advocacy work.']"
+       " 'was born on June 1, 1974, in Ottawa, Canada. Morissette began her music career',\n",
+       " 'in the early 1990s and gained international recognition with her third studio',\n",
+       " 'album, \"Jagged Little Pill,\" released in 1995. The album was a huge commercial',\n",
+       " 'success, selling millions of copies worldwide and earning Morissette several',\n",
+       " 'Grammy Awards.  Throughout her career, Morissette has released numerous',\n",
+       " 'successful albums and has continued to evolve her musical style, incorporating',\n",
+       " 'elements of rock, pop, and alternative music. Some of her popular songs include',\n",
+       " '\"You Oughta Know,\" \"Ironic,\" and \"Hand in My Pocket.\"  Besides music, Morissette',\n",
+       " 'has also ventured into acting, with appearances in movies and TV shows. She has',\n",
+       " 'been involved in various philanthropic activities and has spoken openly about',\n",
+       " 'her personal struggles with eating disorders and mental health.  Overall, Alanis',\n",
+       " 'Morissette has had a successful and influential career in the music industry,',\n",
+       " 'leaving a lasting impact with her powerful and introspective lyrics.']"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -975,14 +771,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken with cache: 0.058038949966430664\n",
+      "Time taken with cache: 0.22634601593017578\n",
       "\n"
      ]
     },
@@ -990,28 +786,22 @@
      "data": {
       "text/plain": [
        "['Alanis Morissette is a Canadian-American singer, songwriter, and actress. She',\n",
-       " 'was born on June 1, 1974, in Ottawa, Ontario, Canada. Morissette began her music',\n",
-       " 'career at a young age, signing a record deal at the age of 14. She gained',\n",
-       " 'international fame with her third studio album, \"Jagged Little Pill,\" released',\n",
-       " 'in 1995. The album was a huge success, selling millions of copies worldwide and',\n",
-       " 'earning her multiple awards, including four Grammy Awards.  Throughout her',\n",
-       " 'career, Morissette has released several successful albums and singles, covering',\n",
-       " 'a variety of genres like alternative rock, pop, and folk. Some of her popular',\n",
-       " 'songs include \"Ironic,\" \"You Oughta Know,\" and \"Hand in My Pocket.\"  Apart from',\n",
-       " 'her music career, Alanis Morissette has also appeared in movies and television',\n",
-       " 'shows. She made her acting debut in the film \"Dogma\" in 1999 and has since',\n",
-       " 'appeared in films like \"Jay and Silent Bob Strike Back\" and \"Weeds.\"  In',\n",
-       " 'addition to her artistic pursuits, Morissette is known for her activism and',\n",
-       " 'advocacy work. She is an advocate for mental health awareness and has spoken',\n",
-       " 'openly about her experiences with depression and eating disorders. Morissette',\n",
-       " 'has also been involved in various charitable initiatives and supported',\n",
-       " 'organizations like Amnesty International and the David Lynch Foundation.',\n",
-       " 'Overall, Alanis Morissette has had a successful and impactful career in the',\n",
-       " 'music industry, becoming one of the most prominent female artists of her',\n",
-       " 'generation. She continues to create music, perform, and engage in advocacy work.']"
+       " 'was born on June 1, 1974, in Ottawa, Canada. Morissette began her music career',\n",
+       " 'in the early 1990s and gained international recognition with her third studio',\n",
+       " 'album, \"Jagged Little Pill,\" released in 1995. The album was a huge commercial',\n",
+       " 'success, selling millions of copies worldwide and earning Morissette several',\n",
+       " 'Grammy Awards.  Throughout her career, Morissette has released numerous',\n",
+       " 'successful albums and has continued to evolve her musical style, incorporating',\n",
+       " 'elements of rock, pop, and alternative music. Some of her popular songs include',\n",
+       " '\"You Oughta Know,\" \"Ironic,\" and \"Hand in My Pocket.\"  Besides music, Morissette',\n",
+       " 'has also ventured into acting, with appearances in movies and TV shows. She has',\n",
+       " 'been involved in various philanthropic activities and has spoken openly about',\n",
+       " 'her personal struggles with eating disorders and mental health.  Overall, Alanis',\n",
+       " 'Morissette has had a successful and influential career in the music industry,',\n",
+       " 'leaving a lasting impact with her powerful and introspective lyrics.']"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1026,14 +816,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken with the cache: 0.05286812782287598\n",
+      "Time taken with the cache: 0.48161983489990234\n",
       "\n"
      ]
     },
@@ -1041,28 +831,22 @@
      "data": {
       "text/plain": [
        "['Alanis Morissette is a Canadian-American singer, songwriter, and actress. She',\n",
-       " 'was born on June 1, 1974, in Ottawa, Ontario, Canada. Morissette began her music',\n",
-       " 'career at a young age, signing a record deal at the age of 14. She gained',\n",
-       " 'international fame with her third studio album, \"Jagged Little Pill,\" released',\n",
-       " 'in 1995. The album was a huge success, selling millions of copies worldwide and',\n",
-       " 'earning her multiple awards, including four Grammy Awards.  Throughout her',\n",
-       " 'career, Morissette has released several successful albums and singles, covering',\n",
-       " 'a variety of genres like alternative rock, pop, and folk. Some of her popular',\n",
-       " 'songs include \"Ironic,\" \"You Oughta Know,\" and \"Hand in My Pocket.\"  Apart from',\n",
-       " 'her music career, Alanis Morissette has also appeared in movies and television',\n",
-       " 'shows. She made her acting debut in the film \"Dogma\" in 1999 and has since',\n",
-       " 'appeared in films like \"Jay and Silent Bob Strike Back\" and \"Weeds.\"  In',\n",
-       " 'addition to her artistic pursuits, Morissette is known for her activism and',\n",
-       " 'advocacy work. She is an advocate for mental health awareness and has spoken',\n",
-       " 'openly about her experiences with depression and eating disorders. Morissette',\n",
-       " 'has also been involved in various charitable initiatives and supported',\n",
-       " 'organizations like Amnesty International and the David Lynch Foundation.',\n",
-       " 'Overall, Alanis Morissette has had a successful and impactful career in the',\n",
-       " 'music industry, becoming one of the most prominent female artists of her',\n",
-       " 'generation. She continues to create music, perform, and engage in advocacy work.']"
+       " 'was born on June 1, 1974, in Ottawa, Canada. Morissette began her music career',\n",
+       " 'in the early 1990s and gained international recognition with her third studio',\n",
+       " 'album, \"Jagged Little Pill,\" released in 1995. The album was a huge commercial',\n",
+       " 'success, selling millions of copies worldwide and earning Morissette several',\n",
+       " 'Grammy Awards.  Throughout her career, Morissette has released numerous',\n",
+       " 'successful albums and has continued to evolve her musical style, incorporating',\n",
+       " 'elements of rock, pop, and alternative music. Some of her popular songs include',\n",
+       " '\"You Oughta Know,\" \"Ironic,\" and \"Hand in My Pocket.\"  Besides music, Morissette',\n",
+       " 'has also ventured into acting, with appearances in movies and TV shows. She has',\n",
+       " 'been involved in various philanthropic activities and has spoken openly about',\n",
+       " 'her personal struggles with eating disorders and mental health.  Overall, Alanis',\n",
+       " 'Morissette has had a successful and influential career in the music industry,',\n",
+       " 'leaving a lasting impact with her powerful and introspective lyrics.']"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1077,13 +861,6 @@
     "print(f\"Time taken with the cache: {time.time() - start}\\n\")\n",
     "textwrap.wrap(answer, width=80)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1102,7 +879,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   },
   "orig_nbformat": 4
  },

--- a/docs/user_guide/getting_started_01.ipynb
+++ b/docs/user_guide/getting_started_01.ipynb
@@ -211,8 +211,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m13:15:04\u001b[0m \u001b[35msam.partee-NW9MQX5Y74\u001b[0m \u001b[34mredisvl.cli.index[13683]\u001b[0m \u001b[1;30mINFO\u001b[0m Indices:\n",
-      "\u001b[32m13:15:04\u001b[0m \u001b[35msam.partee-NW9MQX5Y74\u001b[0m \u001b[34mredisvl.cli.index[13683]\u001b[0m \u001b[1;30mINFO\u001b[0m 1. user_index\n"
+      "\u001b[32m14:56:24\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   Indices:\n",
+      "\u001b[32m14:56:24\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   1. user_index\n"
      ]
     }
    ],
@@ -258,7 +258,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>age</th><th>job</th><th>credit_score</th></tr><tr><td>0</td><td>john</td><td>1</td><td>engineer</td><td>high</td></tr><tr><td>0</td><td>mary</td><td>2</td><td>doctor</td><td>low</td></tr><tr><td>0.653301358223</td><td>joe</td><td>3</td><td>dentist</td><td>medium</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>age</th><th>job</th><th>credit_score</th></tr><tr><td>v1:7f2670effaa140adacc13a4a74eac358</td><td>0</td><td>john</td><td>1</td><td>engineer</td><td>high</td></tr><tr><td>v1:7f01fd2181f44eb181caf6262b1a2a6e</td><td>0</td><td>mary</td><td>2</td><td>doctor</td><td>low</td></tr><tr><td>v1:6a6fee8801cd48ecadad722cca4962bf</td><td>0.653301358223</td><td>joe</td><td>3</td><td>dentist</td><td>medium</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -303,7 +303,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>age</th><th>job</th><th>credit_score</th></tr><tr><td>0</td><td>john</td><td>1</td><td>engineer</td><td>high</td></tr><tr><td>0</td><td>mary</td><td>2</td><td>doctor</td><td>low</td></tr><tr><td>0.653301358223</td><td>joe</td><td>3</td><td>dentist</td><td>medium</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>age</th><th>job</th><th>credit_score</th></tr><tr><td>v1:7f2670effaa140adacc13a4a74eac358</td><td>0</td><td>john</td><td>1</td><td>engineer</td><td>high</td></tr><tr><td>v1:7f01fd2181f44eb181caf6262b1a2a6e</td><td>0</td><td>mary</td><td>2</td><td>doctor</td><td>low</td></tr><tr><td>v1:6a6fee8801cd48ecadad722cca4962bf</td><td>0.653301358223</td><td>joe</td><td>3</td><td>dentist</td><td>medium</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -319,7 +319,7 @@
     "\n",
     "# run the same query\n",
     "results = existing_index.query(query)\n",
-    "result_print(results)\n"
+    "result_print(results)"
    ]
   },
   {
@@ -333,13 +333,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>age</th><th>job</th><th>credit_score</th></tr><tr><td>0</td><td>john</td><td>1</td><td>engineer</td><td>high</td></tr><tr><td>0</td><td>mary</td><td>2</td><td>doctor</td><td>low</td></tr><tr><td>0.653301358223</td><td>joe</td><td>3</td><td>dentist</td><td>medium</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>age</th><th>job</th><th>credit_score</th></tr><tr><td>v1:ecac61a5802448f695d775d50e925826</td><td>0</td><td>john</td><td>1</td><td>engineer</td><td>high</td></tr><tr><td>v1:20198d650bb84295a9c718680a7506b1</td><td>0</td><td>mary</td><td>2</td><td>doctor</td><td>low</td></tr><tr><td>v1:a7e9aa9466834e00ab91f69aae7bc71e</td><td>0.653301358223</td><td>joe</td><td>3</td><td>dentist</td><td>medium</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -387,7 +387,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/docs/user_guide/hybrid_queries_02.ipynb
+++ b/docs/user_guide/hybrid_queries_02.ipynb
@@ -95,8 +95,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32m19:22:36\u001b[0m \u001b[35msam.partee-NW9MQX5Y74\u001b[0m \u001b[34mredisvl.cli.index[21909]\u001b[0m \u001b[1;30mINFO\u001b[0m Indices:\n",
-      "\u001b[32m19:22:36\u001b[0m \u001b[35msam.partee-NW9MQX5Y74\u001b[0m \u001b[34mredisvl.cli.index[21909]\u001b[0m \u001b[1;30mINFO\u001b[0m 1. user_index\n"
+      "\u001b[32m14:57:05\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   Indices:\n",
+      "\u001b[32m14:57:05\u001b[0m \u001b[34m[RedisVL]\u001b[0m \u001b[1;30mINFO\u001b[0m   1. user_index\n"
      ]
     }
    ],
@@ -142,7 +142,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>0.158809006214</td><td>tim</td><td>high</td><td>12</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr><tr><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>v1:b1e376e6003844c8a33b3c953a249948</td><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>v1:4f5a69e97b2a4017998bd30fb23e3339</td><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>v1:f94d6b668b6b4f00851ffb0a9d497c53</td><td>0.158809006214</td><td>tim</td><td>high</td><td>12</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr><tr><td>v1:e9f9b5fe5e47414986139bd61ee60920</td><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -184,7 +184,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>0.653301358223</td><td>joe</td><td>medium</td><td>35</td><td>dentist</td><td>-122.0839,37.3861</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>v1:b1e376e6003844c8a33b3c953a249948</td><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>v1:4f5a69e97b2a4017998bd30fb23e3339</td><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>v1:e9f9b5fe5e47414986139bd61ee60920</td><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>v1:e3ee268f2af94d73a308fb6f42d4ef3e</td><td>0.653301358223</td><td>joe</td><td>medium</td><td>35</td><td>dentist</td><td>-122.0839,37.3861</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -220,7 +220,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>0</td><td>derrick</td><td>low</td><td>14</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>v1:55be34aa947e47edb6d7cb9a894aca6d</td><td>0</td><td>derrick</td><td>low</td><td>14</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>v1:e9f9b5fe5e47414986139bd61ee60920</td><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -257,7 +257,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>0</td><td>derrick</td><td>low</td><td>14</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>v1:b1e376e6003844c8a33b3c953a249948</td><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>v1:55be34aa947e47edb6d7cb9a894aca6d</td><td>0</td><td>derrick</td><td>low</td><td>14</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>v1:e9f9b5fe5e47414986139bd61ee60920</td><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -286,7 +286,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>0</td><td>derrick</td><td>low</td><td>14</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>0.158809006214</td><td>tim</td><td>high</td><td>12</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr><tr><td>0.217882037163</td><td>taimur</td><td>low</td><td>15</td><td>CEO</td><td>-122.0839,37.3861</td></tr><tr><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>0.653301358223</td><td>joe</td><td>medium</td><td>35</td><td>dentist</td><td>-122.0839,37.3861</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>v1:b1e376e6003844c8a33b3c953a249948</td><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>v1:55be34aa947e47edb6d7cb9a894aca6d</td><td>0</td><td>derrick</td><td>low</td><td>14</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>v1:4f5a69e97b2a4017998bd30fb23e3339</td><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>v1:f94d6b668b6b4f00851ffb0a9d497c53</td><td>0.158809006214</td><td>tim</td><td>high</td><td>12</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr><tr><td>v1:9cb99c4dd6274fe89017ae80742fd96a</td><td>0.217882037163</td><td>taimur</td><td>low</td><td>15</td><td>CEO</td><td>-122.0839,37.3861</td></tr><tr><td>v1:e9f9b5fe5e47414986139bd61ee60920</td><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>v1:e3ee268f2af94d73a308fb6f42d4ef3e</td><td>0.653301358223</td><td>joe</td><td>medium</td><td>35</td><td>dentist</td><td>-122.0839,37.3861</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -322,7 +322,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>v1:b1e376e6003844c8a33b3c953a249948</td><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>v1:4f5a69e97b2a4017998bd30fb23e3339</td><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>v1:e9f9b5fe5e47414986139bd61ee60920</td><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -364,7 +364,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>0.158809006214</td><td>tim</td><td>high</td><td>12</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>v1:f94d6b668b6b4f00851ffb0a9d497c53</td><td>0.158809006214</td><td>tim</td><td>high</td><td>12</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -402,7 +402,7 @@
     {
      "data": {
       "text/html": [
-       "<table><tr><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>0.158809006214</td><td>tim</td><td>high</td><td>12</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr><tr><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>0.653301358223</td><td>joe</td><td>medium</td><td>35</td><td>dentist</td><td>-122.0839,37.3861</td></tr></table>"
+       "<table><tr><th>id</th><th>vector_distance</th><th>user</th><th>credit_score</th><th>age</th><th>job</th><th>office_location</th></tr><tr><td>v1:b1e376e6003844c8a33b3c953a249948</td><td>0</td><td>john</td><td>high</td><td>18</td><td>engineer</td><td>-122.4194,37.7749</td></tr><tr><td>v1:4f5a69e97b2a4017998bd30fb23e3339</td><td>0.109129190445</td><td>tyler</td><td>high</td><td>100</td><td>engineer</td><td>-122.0839,37.3861</td></tr><tr><td>v1:f94d6b668b6b4f00851ffb0a9d497c53</td><td>0.158809006214</td><td>tim</td><td>high</td><td>12</td><td>dermatologist</td><td>-122.0839,37.3861</td></tr><tr><td>v1:e9f9b5fe5e47414986139bd61ee60920</td><td>0.266666650772</td><td>nancy</td><td>high</td><td>94</td><td>doctor</td><td>-122.4194,37.7749</td></tr><tr><td>v1:e3ee268f2af94d73a308fb6f42d4ef3e</td><td>0.653301358223</td><td>joe</td><td>medium</td><td>35</td><td>dentist</td><td>-122.0839,37.3861</td></tr></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -505,10 +505,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'id': 'v1:38bfee0253ca452e96b4b3fdcb2798f7', 'payload': None, 'user': 'john', 'age': '18', 'job': 'engineer', 'credit_score': 'high', 'office_location': '-122.4194,37.7749', 'user_embedding': '==\\x00\\x00\\x00?'}\n",
-      "{'id': 'v1:747bce550564443199ae1118cf03b5e3', 'payload': None, 'user': 'nancy', 'age': '94', 'job': 'doctor', 'credit_score': 'high', 'office_location': '-122.4194,37.7749', 'user_embedding': '333?=\\x00\\x00\\x00?'}\n",
-      "{'id': 'v1:da7b6b0bf94f4c40a2ea23e20035ca73', 'payload': None, 'user': 'tyler', 'age': '100', 'job': 'engineer', 'credit_score': 'high', 'office_location': '-122.0839,37.3861', 'user_embedding': '=>\\x00\\x00\\x00?'}\n",
-      "{'id': 'v1:abcdf6be4fb042389a93a9b27d6cce5c', 'payload': None, 'user': 'tim', 'age': '12', 'job': 'dermatologist', 'credit_score': 'high', 'office_location': '-122.0839,37.3861', 'user_embedding': '>>\\x00\\x00\\x00?'}\n"
+      "{'id': 'v1:b1e376e6003844c8a33b3c953a249948', 'payload': None, 'user': 'john', 'age': '18', 'job': 'engineer', 'credit_score': 'high', 'office_location': '-122.4194,37.7749', 'user_embedding': '==\\x00\\x00\\x00?'}\n",
+      "{'id': 'v1:e9f9b5fe5e47414986139bd61ee60920', 'payload': None, 'user': 'nancy', 'age': '94', 'job': 'doctor', 'credit_score': 'high', 'office_location': '-122.4194,37.7749', 'user_embedding': '333?=\\x00\\x00\\x00?'}\n",
+      "{'id': 'v1:4f5a69e97b2a4017998bd30fb23e3339', 'payload': None, 'user': 'tyler', 'age': '100', 'job': 'engineer', 'credit_score': 'high', 'office_location': '-122.0839,37.3861', 'user_embedding': '=>\\x00\\x00\\x00?'}\n",
+      "{'id': 'v1:f94d6b668b6b4f00851ffb0a9d497c53', 'payload': None, 'user': 'tim', 'age': '12', 'job': 'dermatologist', 'credit_score': 'high', 'office_location': '-122.0839,37.3861', 'user_embedding': '>>\\x00\\x00\\x00?'}\n"
      ]
     }
    ],
@@ -558,13 +558,6 @@
     "# Using the str() method, you can see what Redis Query this will emit.\n",
     "str(v)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -583,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/docs/user_guide/jupyterutils.py
+++ b/docs/user_guide/jupyterutils.py
@@ -1,4 +1,5 @@
 from IPython.display import display, HTML
+from redis.commands.search.result import Result
 
 def table_print(dict_list):
     # If there's nothing in the list, there's nothing to print
@@ -27,16 +28,17 @@ def table_print(dict_list):
 
 
 def result_print(results):
-    # If there's nothing in the list, there's nothing to print
-    if len(results.docs) == 0:
-        return
+    if isinstance(results, Result):
+        # If there's nothing in the list, there's nothing to print
+        if len(results.docs) == 0:
+            return
 
-    data = [doc.__dict__ for doc in results.docs]
+        results = [doc.__dict__ for doc in results.docs]
 
-    to_remove = ["id", "payload"]
-    for doc in data:
-        for key in to_remove:
-            if key in doc:
-                del doc[key]
+        to_remove = ["id", "payload"]
+        for doc in results:
+            for key in to_remove:
+                if key in doc:
+                    del doc[key]
 
-    table_print(data)
+    table_print(results)

--- a/docs/user_guide/llmcache_03.ipynb
+++ b/docs/user_guide/llmcache_03.ipynb
@@ -25,7 +25,10 @@
    "outputs": [],
    "source": [
     "import openai\n",
-    "openai.api_key = \"sk-<YOUR KEY HERE>\"\n",
+    "import os\n",
+    "import getpass\n",
+    "\n",
+    "api_key = os.getenv(\"OPENAI_API_KEY\") or getpass.getpass(\"Enter your OpenAI API key: \")\n",
     "\n",
     "def ask_openai(question):\n",
     "    response = openai.Completion.create(\n",

--- a/redisvl/__init__.py
+++ b/redisvl/__init__.py
@@ -1,5 +1,3 @@
-
-
 from redisvl.version import __version__
 
 all = ["__version__"]

--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -11,6 +11,7 @@ from redisvl.utils.utils import convert_bytes
 
 logger = get_logger("[RedisVL]")
 
+
 class Index:
     usage = "\n".join(
         [

--- a/redisvl/cli/log.py
+++ b/redisvl/cli/log.py
@@ -5,9 +5,8 @@ import coloredlogs
 
 # constants for logging
 coloredlogs.DEFAULT_DATE_FORMAT = "%H:%M:%S"
-coloredlogs.DEFAULT_LOG_FORMAT = (
-    "%(asctime)s %(name)s %(levelname)s   %(message)s"
-)
+coloredlogs.DEFAULT_LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s   %(message)s"
+
 
 def get_logger(name, log_level="info", fmt=None):
     """Return a logger instance"""

--- a/redisvl/cli/main.py
+++ b/redisvl/cli/main.py
@@ -2,8 +2,8 @@ import argparse
 import sys
 
 from redisvl.cli.index import Index
-from redisvl.cli.version import Version
 from redisvl.cli.log import get_logger
+from redisvl.cli.version import Version
 
 logger = get_logger(__name__)
 

--- a/redisvl/cli/version.py
+++ b/redisvl/cli/version.py
@@ -1,9 +1,10 @@
-import sys
 import argparse
+import sys
 from argparse import Namespace
 
 from redisvl import __version__
 from redisvl.cli.log import get_logger
+
 logger = get_logger("[RedisVL]")
 
 

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Callable
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -23,6 +23,7 @@ def _default_process_results(results: List["Result"]) -> List[Dict[str, Any]]:
     # Convert a list of Result objects into a list of document dicts
     # Process results functions must accept a list of results and return a list
     return [doc.__dict__ for doc in results.docs]
+
 
 class SearchIndexBase:
     def __init__(
@@ -67,13 +68,19 @@ class SearchIndexBase:
         Returns:
             List[Result]: A list of search results
         """
-        process_results = kwargs.pop("process_results") if "process_results" in kwargs else None
-        results: List["Result"] =  self._redis_conn.ft(self._name).search(*args, **kwargs)  # type: ignore
+        process_results = (
+            kwargs.pop("process_results") if "process_results" in kwargs else None
+        )
+        results: List["Result"] = self._redis_conn.ft(self._name).search(*args, **kwargs)  # type: ignore
         if process_results:
             return process_results(results)
         return results
 
-    def query(self, query: BaseQuery, process_results: Optional[Callable] = _default_process_results) -> List[Any]:
+    def query(
+        self,
+        query: BaseQuery,
+        process_results: Optional[Callable] = _default_process_results,
+    ) -> List[Any]:
         """Run a query on this index.
 
         This is similar to the search method, but takes a BaseQuery
@@ -546,13 +553,19 @@ class AsyncSearchIndex(SearchIndexBase):
         Returns:
             List[Result]: A list of search results
         """
-        process_results = kwargs.pop("process_results") if "process_results" in kwargs else None
-        results: List["Result"] =  await self._redis_conn.ft(self._name).search(*args, **kwargs)  # type: ignore
+        process_results = (
+            kwargs.pop("process_results") if "process_results" in kwargs else None
+        )
+        results: List["Result"] = await self._redis_conn.ft(self._name).search(*args, **kwargs)  # type: ignore
         if process_results:
             return process_results(results)
         return results
 
-    async def query(self, query: BaseQuery, process_results: Optional[Callable] = _default_process_results) -> List[Any]:
+    async def query(
+        self,
+        query: BaseQuery,
+        process_results: Optional[Callable] = _default_process_results,
+    ) -> List[Any]:
         """Run a query on this index.
 
         This is similar to the search method, but takes a BaseQuery

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -1,7 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
-
-if TYPE_CHECKING:
-    from redis.commands.search.result import Result
+from typing import List, Optional, Union
 
 from redis.commands.search.field import VectorField
 
@@ -184,7 +181,8 @@ class SemanticCache(BaseLLMCache):
         )
 
         cache_hits: List[str] = []
-        for result in self._index.query(v):
+        results = self._index.search(v.query, query_params=v.params)
+        for result in results.docs:
             sim = similarity(result["vector_distance"])
             if sim > self.threshold:
                 self._refresh_ttl(result["id"])

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -193,7 +193,9 @@ class SemanticCache(BaseLLMCache):
             sim = similarity(doc.vector_distance)
             if sim > self.threshold:
                 self._refresh_ttl(doc.id)
-                cache_hits.append(doc.response)  # TODO what do we actually want to return here?
+                cache_hits.append(
+                    doc.response
+                )  # TODO what do we actually want to return here?
         return cache_hits
 
     def store(

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, List, Optional, Union
 
 if TYPE_CHECKING:
     from redis.commands.search.result import Result
-    from redis.commands.search.document import Document
 
 from redis.commands.search.field import VectorField
 
@@ -142,7 +141,7 @@ class SemanticCache(BaseLLMCache):
         """Clear the LLMCache of all keys in the index"""
         client = self._index.client
         if client:
-            with client.pipeline() as pipe:
+            with client.pipeline(transaction=False) as pipe:
                 for key in client.scan_iter(match=f"{self._index._prefix}:*"):
                     pipe.delete(key)
                 pipe.execute()

--- a/redisvl/utils/utils.py
+++ b/redisvl/utils/utils.py
@@ -1,5 +1,9 @@
 import re
-from typing import Any, List, Optional, Pattern
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern
+
+if TYPE_CHECKING:
+    from redis.commands.search.result import Result
+    from redis.commands.search.document import Document
 
 import numpy as np
 
@@ -78,4 +82,17 @@ def check_redis_modules_exist(client) -> None:
 
 
 def array_to_buffer(array: List[float], dtype: Any = np.float32) -> bytes:
+    """Convert a list of floats into a numpy byte string."""
     return np.array(array).astype(dtype).tobytes()
+
+
+def process_results(results: List["Result"]) -> List[Dict[str, Any]]:
+    """Convert a list of search Result objects into a list of document dicts"""
+
+    def _process(doc: "Document") -> dict:
+        d = doc.__dict__
+        if "payload" in d:
+            del d["payload"]
+        return d
+
+    return [_process(doc) for doc in results.docs]

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -2,7 +2,6 @@ from pprint import pprint
 
 import numpy as np
 import pytest
-
 from redis.commands.search.result import Result
 
 from redisvl.index import SearchIndex

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -3,6 +3,8 @@ from pprint import pprint
 import numpy as np
 import pytest
 
+from redis.commands.search.result import Result
+
 from redisvl.index import SearchIndex
 from redisvl.query import NumericFilter, TagFilter, VectorQuery
 
@@ -117,6 +119,27 @@ def test_simple(index):
         assert int(doc.age) in [18, 14, 94, 100, 12, 15, 35]
         assert doc.job in ["engineer", "doctor", "dermatologist", "CEO", "dentist"]
         assert doc.credit_score in ["high", "low", "medium"]
+
+
+def test_process_results(index):
+    # *=>[KNN 7 @user_embedding $vector AS vector_distance]
+    v = VectorQuery(
+        [0.1, 0.1, 0.5],
+        "user_embedding",
+        return_fields=["user", "credit_score", "age", "job"],
+        num_results=7,
+    )
+    results = index.search(v.query, query_params=v.params)
+    assert isinstance(results, Result)
+    assert len(results.docs) == 7
+
+    query_results = index.query(v, process_results=False)
+    assert isinstance(query_results, Result)
+    assert len(query_results.docs) == 7
+
+    processed_results = index.query(v)
+    assert len(processed_results) == 7
+    assert isinstance(processed_results[0], dict)
 
 
 def test_simple_tag_filter(index):

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -120,7 +120,7 @@ def test_simple(index):
         assert doc.credit_score in ["high", "low", "medium"]
 
 
-def test_process_results(index):
+def test_search_qeury(index):
     # *=>[KNN 7 @user_embedding $vector AS vector_distance]
     v = VectorQuery(
         [0.1, 0.1, 0.5],
@@ -132,13 +132,12 @@ def test_process_results(index):
     assert isinstance(results, Result)
     assert len(results.docs) == 7
 
-    query_results = index.query(v, process_results=False)
-    assert isinstance(query_results, Result)
-    assert len(query_results.docs) == 7
-
     processed_results = index.query(v)
     assert len(processed_results) == 7
     assert isinstance(processed_results[0], dict)
+    result = results.docs[0].__dict__
+    result.pop("payload")
+    assert processed_results[0] == results.docs[0].__dict__
 
 
 def test_simple_tag_filter(index):

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -73,8 +73,8 @@ def test_simple(client):
     )
 
     results = index.search(query.query, query_params=query.params)
-    results_2 = index.query(query, process_results=False)
-    assert len(results.docs) == len(results_2.docs)
+    results_2 = index.query(query)
+    assert len(results.docs) == len(results_2)
 
     # make sure correct users returned
     # users = list(results.docs)

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -73,7 +73,7 @@ def test_simple(client):
     )
 
     results = index.search(query.query, query_params=query.params)
-    results_2 = index.query(query)
+    results_2 = index.query(query, process_results=False)
     assert len(results.docs) == len(results_2.docs)
 
     # make sure correct users returned

--- a/tests/integration/test_simple_async.py
+++ b/tests/integration/test_simple_async.py
@@ -80,7 +80,7 @@ async def test_simple(async_client):
     )
 
     results = await index.search(query.query, query_params=query.params)
-    results_2 = await index.query(query)
+    results_2 = await index.query(query, process_results=False)
     assert len(results.docs) == len(results_2.docs)
 
     # make sure correct users returned

--- a/tests/integration/test_simple_async.py
+++ b/tests/integration/test_simple_async.py
@@ -80,8 +80,8 @@ async def test_simple(async_client):
     )
 
     results = await index.search(query.query, query_params=query.params)
-    results_2 = await index.query(query, process_results=False)
-    assert len(results.docs) == len(results_2.docs)
+    results_2 = await index.query(query)
+    assert len(results.docs) == len(results_2)
 
     # make sure correct users returned
     # users = list(results.docs)


### PR DESCRIPTION
This PR introduces post processing of query/search results from Redis.

- Default processor used for `query` method and left out for `search` method.
- Ability to pass in a `Callable`, using your own processor after results are pulled. Must work on a `List[Result]` object and return a `List[Any]]` object.
- Adds tests.