### PR TITLE
Adding the release drafter

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,48 @@
+name-template: '$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
+autolabeler:
+  - label: 'maintenance'
+    files:
+      - '*.md'
+      - '.github/*'
+  - label: 'bug'
+    branch:
+      - '/bug-.+'
+  - label: 'maintenance'
+    branch:
+      - '/maintenance-.+'
+  - label: 'feature'
+    branch:
+      - '/feature-.+'
+categories:
+  - title: 'Breaking Changes'
+    labels:
+      - 'breakingchange'
+  - title: '🧪 Experimental Features'
+    labels:
+      - 'experimental'
+  - title: '🚀 New Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'BUG'
+  - title: '🧰 Maintenance'
+    label: 'maintenance'
+change-template: '- $TITLE (#$NUMBER)'
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  # Changes
+
+  $CHANGES
+
+  ## Contributors
+  We'd like to thank all the contributors who worked on this release!
+
+  $CONTRIBUTORS
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+permissions: {}
+jobs:
+  update_release_draft:
+    permissions:
+      pull-requests: write  #  to add label to PR (release-drafter/release-drafter)
+      contents: write  #  to create a github release (release-drafter/release-drafter)
+
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+           config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release drafter is used across Redis clients to provide a baseline for valuable release notes, across clients. The goal is not to replace the need to write release notes, but rather to provide a *consistent* basis, and baseline for those.

As part of this, pull request **titles** upon merge to **master** become the comment in a release note. A merged pull request needs to have one of the labels below, thus inserting itself into the right place within the proposed, future release notes.  In no way, does this negate a pull request appearing in multiple locations, nor enforce label requirements.  The labels are as follows:

bug - A pull request with this label will appear within the bugs section.
feature - This label ensures the pull request is marked as a feature
maintenance - Documentation changes, CI changes, and basically ongoing library maintenance work, belong here.
breakingchange - Occasionally, we need to communicate with users, that a change breaks behaviour, or an API. By tagging accordingly, this appears at the top of the release notes.

The action itself, is stored in the workflows folder, whereas the configuration (and hence template) for the github action appears in .github. The proposed configuration is a direct copy from redis-py, as these are used everywhere. Finally, as an example of well generated release notes, for larger changes please see [release 4.5.5](https://github.com/redis/redis-py/releases/tag/v4.5.5)