### PR TITLE
Adding a pypi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 ![GitHub last commit](https://img.shields.io/github/last-commit/RedisVentures/RedisVL)
 ![GitHub deployments](https://img.shields.io/github/deployments/RedisVentures/RedisVL/github-pages?label=doc%20build)
+![pypi](https://badge.fury.io/py/redisvl.svg)](https://pypi.org/project/redisvl/)
 
 </div>
 


### PR DESCRIPTION
Adding a badge to the README indicating the latest version of the library, as deployed to PyPi