### PR TITLE
make prefix optional and update vector field args

### DIFF
--- a/redisvl/cli/index.py
+++ b/redisvl/cli/index.py
@@ -90,7 +90,7 @@ class Index:
         """Delete an index
 
         Usage:
-            redisvl index delete -i <index_name> | -s <schema_path>
+            rvl index delete -i <index_name> | -s <schema_path>
         """
         index = self._connect_to_index(args)
         index.delete(drop=drop)

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -169,7 +169,7 @@ class SearchIndexBase:
                 key = record[key_field]  # type: ignore
             except KeyError:
                 raise ValueError(f"Key field {key_field} not found in record {record}")
-        return f"{self._prefix}:{key}"
+        return f"{self._prefix}:{key}" if self._prefix else key
 
     @check_connected("_redis_conn")
     def info(self) -> Dict[str, Any]:

--- a/redisvl/schema.py
+++ b/redisvl/schema.py
@@ -64,7 +64,6 @@ class BaseVectorField(BaseModel):
     algorithm: object = Field(...)
     datatype: str = Field(default="FLOAT32")
     distance_metric: str = Field(default="COSINE")
-    initial_cap: int = Field(default=20000)
 
     @validator("algorithm", "datatype", "distance_metric", pre=True, each_item=True)
     def uppercase_strings(cls, v):
@@ -73,7 +72,6 @@ class BaseVectorField(BaseModel):
 
 class FlatVectorField(BaseVectorField):
     algorithm: object = Literal["FLAT"]
-    block_size: int = Field(default=1000)
 
     def as_field(self):
         return VectorField(
@@ -83,8 +81,6 @@ class FlatVectorField(BaseVectorField):
                 "TYPE": self.datatype,
                 "DIM": self.dims,
                 "DISTANCE_METRIC": self.distance_metric,
-                "INITIAL_CAP": self.initial_cap,
-                "BLOCK_SIZE": self.block_size,
             },
         )
 
@@ -104,7 +100,6 @@ class HNSWVectorField(BaseVectorField):
                 "TYPE": self.datatype,
                 "DIM": self.dims,
                 "DISTANCE_METRIC": self.distance_metric,
-                "INITIAL_CAP": self.initial_cap,
                 "M": self.m,
                 "EF_CONSTRUCTION": self.ef_construction,
                 "EF_RUNTIME": self.ef_runtime,
@@ -115,7 +110,7 @@ class HNSWVectorField(BaseVectorField):
 
 class IndexModel(BaseModel):
     name: str = Field(...)
-    prefix: str = Field(...)
+    prefix: Optional[str] = Field(default="")
     storage_type: Optional[str] = Field(default="hash")
 
 


### PR DESCRIPTION
This PR makes the `prefix` field optional and an empty string by default, which mirrors the default because of the RediSearch API. It also removes the vector field args for block size and initial cap as these are not user friendly fields.