### PR TITLE
Add support for CountQuery

### DIFF
--- a/docs/user_guide/hybrid_queries_02.ipynb
+++ b/docs/user_guide/hybrid_queries_02.ipynb
@@ -195,6 +195,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# multiple tags\n",
+    "t = Tag(\"credit_score\") == [\"high\", \"medium\"]\n",
+    "\n",
+    "v.set_filter(t)\n",
+    "result_print(index.query(v))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -590,6 +603,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Count Queries\n",
+    "\n",
+    "In some cases, you may need to use a ``FilterExpression`` to execute a ``CountQuery`` that simply returns the count of the number of entities in the pertaining set. It is similar to the ``FilterQuery`` class but does not return the values of the underlying data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from redisvl.query import CountQuery\n",
+    "\n",
+    "has_low_credit = Tag(\"credit_score\") == \"low\"\n",
+    "\n",
+    "filter_query = CountQuery(filter_expression=has_low_credit)\n",
+    "\n",
+    "results = index.search(filter_query)\n",
+    "\n",
+    "print(f\"{results.total} records match the filter expression {str(has_low_credit)} for the given index.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Range Queries\n",
     "\n",
     "Range Queries are a useful method to perform a vector search where only results within a vector ``distance_threshold`` are returned. This enables the user to find all records within their dataset that are similar to a query vector where \"similar\" is defined by a quantitative value."
@@ -846,7 +885,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.9.12"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/docs/user_guide/hybrid_queries_02.ipynb
+++ b/docs/user_guide/hybrid_queries_02.ipynb
@@ -620,7 +620,7 @@
     "\n",
     "filter_query = CountQuery(filter_expression=has_low_credit)\n",
     "\n",
-    "results = index.search(filter_query)\n",
+    "results = index.search(filter_query.query)\n",
     "\n",
     "print(f\"{results.total} records match the filter expression {str(has_low_credit)} for the given index.\")"
    ]

--- a/redisvl/query/__init__.py
+++ b/redisvl/query/__init__.py
@@ -1,3 +1,8 @@
-from redisvl.query.query import FilterQuery, RangeQuery, VectorQuery
+from redisvl.query.query import FilterQuery, RangeQuery, VectorQuery, CountQuery
 
-__all__ = ["VectorQuery", "FilterQuery", "RangeQuery"]
+__all__ = [
+    "VectorQuery",
+    "FilterQuery",
+    "RangeQuery",
+    "CountQuery"
+]

--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -41,6 +41,8 @@ class CountQuery(BaseQuery):
             >>> from redisvl.query.filter import Tag
             >>> t = Tag("brand") == "Nike"
             >>> q = CountQuery(filter_expression=t)
+            >>> results = index.search(q.query)
+            >>> count = results.total
         """
         self.set_filter(filter_expression)
         self._params = params

--- a/redisvl/query/query.py
+++ b/redisvl/query/query.py
@@ -21,6 +21,84 @@ class BaseQuery:
         raise NotImplementedError
 
 
+class CountQuery(BaseQuery):
+    def __init__(
+        self,
+        filter_expression: FilterExpression,
+        params: Optional[Dict[str, Any]] = None,
+    ):
+        """Query for a simple count operation on a filter expression.
+
+        Args:
+            filter_expression (FilterExpression): The filter expression to query for.
+            params (Optional[Dict[str, Any]], optional): The parameters for the query. Defaults to None.
+
+        Raises:
+            TypeError: If filter_expression is not of type redisvl.query.FilterExpression
+
+        Examples:
+            >>> from redisvl.query import CountQuery
+            >>> from redisvl.query.filter import Tag
+            >>> t = Tag("brand") == "Nike"
+            >>> q = CountQuery(filter_expression=t)
+        """
+        self.set_filter(filter_expression)
+        self._params = params
+
+    def __str__(self) -> str:
+        return " ".join([str(x) for x in self.query.get_args()])
+
+    def set_filter(self, filter_expression: FilterExpression):
+        """Set the filter for the query.
+
+        Args:
+            filter_expression (FilterExpression): The filter to apply to the query.
+
+        Raises:
+            TypeError: If filter_expression is not of type redisvl.query.FilterExpression
+        """
+        if not isinstance(filter_expression, FilterExpression):
+            raise TypeError(
+                "filter_expression must be of type redisvl.query.FilterExpression"
+            )
+        self._filter = filter_expression
+
+    def get_filter(self) -> FilterExpression:
+        """Get the filter for the query.
+
+        Returns:
+            FilterExpression: The filter for the query.
+        """
+        return self._filter
+
+    @property
+    def query(self) -> Query:
+        """Return a Redis-Py Query object representing the query.
+
+        Returns:
+            redis.commands.search.query.Query: The query object.
+        """
+        base_query = str(self._filter)
+        query = (
+            Query(base_query)
+            .no_content()
+            .dialect(2)
+        )
+        return query
+
+    @property
+    def params(self) -> Dict[str, Any]:
+        """Return the parameters for the query.
+
+        Returns:
+            Dict[str, Any]: The parameters for the query.
+        """
+        if not self._params:
+            self._params = {}
+        return self._params
+
+
+
 class FilterQuery(BaseQuery):
     def __init__(
         self,

--- a/tests/integration/test_query.py
+++ b/tests/integration/test_query.py
@@ -5,8 +5,8 @@ import pytest
 from redis.commands.search.result import Result
 
 from redisvl.index import SearchIndex
-from redisvl.query import FilterQuery, RangeQuery, VectorQuery
-from redisvl.query.filter import Geo, GeoRadius, Num, Tag, Text
+from redisvl.query import FilterQuery, RangeQuery, VectorQuery, CountQuery
+from redisvl.query.filter import FilterExpression, Geo, GeoRadius, Num, Tag, Text
 
 data = [
     {
@@ -170,6 +170,18 @@ def test_range_query(index):
         assert float(result["vector_distance"]) <= 0.1
     assert len(results) == 2
 
+
+def test_count_query(index):
+    c = CountQuery(FilterExpression("*"))
+    results = index.query(c)
+    assert len(results) == len(data)
+
+    c = CountQuery(Tag("credit_score") == "high")
+    results = index.query(c)
+    assert len(results) == 4
+
+    results = index.search(c.query)
+    assert results.total == 4
 
 vector_query = VectorQuery(
     vector=[0.1, 0.1, 0.5],


### PR DESCRIPTION
Adds support for a simple `CountQuery` which expects a `FilterExpression` and allows users to check how many records match a particular set of filters. Also adds documentation and examples for multiple tag fields and count queries.

