### PR TITLE
Update key prefix and access method

### DIFF
--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -152,6 +152,18 @@ class SearchIndexBase:
         self._redis_conn = None
 
     def key(self, key_value: str) -> str:
+        """
+        Create a redis key as a combination of an index key prefix (optional) and specified key value.
+        The key value is typically a unique identifier, created at random, or derived from
+        some specified metadata.
+
+        Args:
+            key_value (str): The specified unique identifier for a particular document
+                             indexed in Redis.
+
+        Returns:
+            str: The full Redis key including key prefix and value as a string.
+        """
         return f"{self._prefix}:{key_value}" if self._prefix else key_value
 
     def _create_key(

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -154,7 +154,9 @@ class SearchIndexBase:
     def key(self, key_value: str) -> str:
         return f"{self._prefix}:{key_value}" if self._prefix else key_value
 
-    def _create_key(self, record: Dict[str, Any], key_field: Optional[str] = None) -> str:
+    def _create_key(
+        self, record: Dict[str, Any], key_field: Optional[str] = None
+    ) -> str:
         """Construct the Redis HASH top level key.
 
         Args:
@@ -343,10 +345,7 @@ class SearchIndex(SearchIndexBase):
 
     @check_connected("_redis_conn")
     def load(
-        self,
-        data: Iterable[Dict[str, Any]],
-        key_field: Optional[str] = None,
-        **kwargs
+        self, data: Iterable[Dict[str, Any]], key_field: Optional[str] = None, **kwargs
     ):
         """Load data into Redis and index using this SearchIndex object.
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -18,6 +18,14 @@ def test_search_index_get_key():
     assert "foo" not in key
 
 
+def test_search_index_no_prefix():
+    # specify None as the prefix...
+    si = SearchIndex("my_index", prefix=None, fields=fields)
+    key = si.key("foo")
+    assert not si._prefix
+    assert key == "foo"
+
+
 def test_search_index_client(client):
     si = SearchIndex("my_index", fields=fields)
     si.set_client(client)
@@ -29,6 +37,7 @@ def test_search_index_create(client, redis_url):
     si = SearchIndex("my_index", fields=fields)
     si.set_client(client)
     si.create(overwrite=True)
+    assert si.exists()
     assert "my_index" in convert_bytes(si.client.execute_command("FT._LIST"))
 
     s1_2 = SearchIndex.from_existing("my_index", url=redis_url)
@@ -40,7 +49,6 @@ def test_search_index_delete(client):
     si.set_client(client)
     si.create(overwrite=True)
     si.delete()
-
     assert "my_index" not in convert_bytes(si.client.execute_command("FT._LIST"))
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -11,10 +11,10 @@ fields = [TagField("test")]
 def test_search_index_get_key():
     si = SearchIndex("my_index", fields=fields)
     key = si.key("foo")
-    assert key.startswith(si._key_prefix)
+    assert key.startswith(si._prefix)
     assert "foo" in key
     key = si._create_key({"id": "foo"})
-    assert key.startswith(si._key_prefix)
+    assert key.startswith(si._prefix)
     assert "foo" not in key
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -10,11 +10,11 @@ fields = [TagField("test")]
 
 def test_search_index_get_key():
     si = SearchIndex("my_index", fields=fields)
-    key = si._get_key({"id": "foo"}, "id")
-    assert key.startswith(si._prefix)
+    key = si.key("foo")
+    assert key.startswith(si._key_prefix)
     assert "foo" in key
-    key = si._get_key({"id": "foo"})
-    assert key.startswith(si._prefix)
+    key = si._create_key({"id": "foo"})
+    assert key.startswith(si._key_prefix)
     assert "foo" not in key
 
 


### PR DESCRIPTION
After working through arxiv example, this is a small adjustment to help with usability:
- adds an explicit `key` method help function that combines the index key prefix + in addition to the records identifier to create the key name
- updates the other private method from `_get_key` to `_create_key` to be more specific