### PR TITLE
Add optional data load preprocessor hook

### DIFF
--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -403,9 +403,13 @@ class SearchIndex(SearchIndexBase):
                         try:
                             record = preprocess(record)
                         except Exception as e:
-                            raise RuntimeError("Error while preprocessing records on load") from e
+                            raise RuntimeError(
+                                "Error while preprocessing records on load"
+                            ) from e
                     if not isinstance(record, dict):
-                        raise TypeError(f"Individual records must be of type dict, got type {type(record)}")
+                        raise TypeError(
+                            f"Individual records must be of type dict, got type {type(record)}"
+                        )
                     # Write the record to Redis
                     pipe.hset(key, mapping=record)  # type: ignore
                     if ttl:
@@ -573,9 +577,13 @@ class AsyncSearchIndex(SearchIndexBase):
                     try:
                         record = preprocess(record)
                     except Exception as e:
-                        raise RuntimeError("Error while preprocessing records on load") from e
+                        raise RuntimeError(
+                            "Error while preprocessing records on load"
+                        ) from e
                 if not isinstance(record, dict):
-                    raise TypeError(f"Individual records must be of type dict, got type {type(record)}")
+                    raise TypeError(
+                        f"Individual records must be of type dict, got type {type(record)}"
+                    )
                 # Write the record to Redis
                 await self._redis_conn.hset(key, mapping=record)  # type: ignore
                 if ttl:

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -357,10 +357,7 @@ class SearchIndex(SearchIndexBase):
 
     @check_connected("_redis_conn")
     def load(
-        self,
-        data: Iterable[Dict[str, Any]],
-        key_field: Optional[str] = None,
-        **kwargs
+        self, data: Iterable[Dict[str, Any]], key_field: Optional[str] = None, **kwargs
     ):
         """Load data into Redis and index using this SearchIndex object.
 

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -29,12 +29,12 @@ class SearchIndexBase:
     def __init__(
         self,
         name: str,
-        key_prefix: str = "rvl",
+        prefix: str = "rvl",
         storage_type: str = "hash",
         fields: Optional[List["Field"]] = None,
     ):
         self._name = name
-        self._key_prefix = key_prefix
+        self._prefix = prefix
         self._storage = storage_type
         self._fields = fields
         self._redis_conn: Optional[redis.Redis] = None
@@ -255,11 +255,11 @@ class SearchIndex(SearchIndexBase):
     def __init__(
         self,
         name: str,
-        key_prefix: str = "rvl",
+        prefix: str = "rvl",
         storage_type: str = "hash",
         fields: Optional[List["Field"]] = None,
     ):
-        super().__init__(name, key_prefix, storage_type, fields)
+        super().__init__(name, prefix, storage_type, fields)
 
     @classmethod
     def from_existing(
@@ -290,11 +290,11 @@ class SearchIndex(SearchIndexBase):
         info = convert_bytes(client.ft(name).info())
         index_definition = make_dict(info["index_definition"])
         storage_type = index_definition["key_type"].lower()
-        key_prefix = index_definition["prefixes"][0]
+        prefix = index_definition["prefixes"][0]
         instance = cls(
             name=name,
             storage_type=storage_type,
-            key_prefix=key_prefix,
+            prefix=prefix,
             fields=fields,
         )
         instance.set_client(client)
@@ -339,7 +339,7 @@ class SearchIndex(SearchIndexBase):
         # will raise correct response error if index already exists
         self._redis_conn.ft(self._name).create_index(  # type: ignore
             fields=self._fields,
-            definition=IndexDefinition(prefix=[self._key_prefix], index_type=storage_type),
+            definition=IndexDefinition(prefix=[self._prefix], index_type=storage_type),
         )
 
     @check_connected("_redis_conn")
@@ -416,11 +416,11 @@ class AsyncSearchIndex(SearchIndexBase):
     def __init__(
         self,
         name: str,
-        key_prefix: str = "rvl",
+        prefix: str = "rvl",
         storage_type: str = "hash",
         fields: Optional[List["Field"]] = None,
     ):
-        super().__init__(name, key_prefix, storage_type, fields)
+        super().__init__(name, prefix, storage_type, fields)
 
     @classmethod
     async def from_existing(
@@ -451,11 +451,11 @@ class AsyncSearchIndex(SearchIndexBase):
         info = convert_bytes(await client.ft(name).info())
         index_definition = make_dict(info["index_definition"])
         storage_type = index_definition["key_type"].lower()
-        key_prefix = index_definition["prefixes"][0]
+        prefix = index_definition["prefixes"][0]
         instance = cls(
             name=name,
             storage_type=storage_type,
-            key_prefix=key_prefix,
+            prefix=prefix,
             fields=fields,
         )
         instance.set_client(client)
@@ -495,7 +495,7 @@ class AsyncSearchIndex(SearchIndexBase):
         # Create Index
         await self._redis_conn.ft(self._name).create_index(  # type: ignore
             fields=self._fields,
-            definition=IndexDefinition(prefix=[self._key_prefix], index_type=storage_type),
+            definition=IndexDefinition(prefix=[self._prefix], index_type=storage_type),
         )
 
     @check_connected("_redis_conn")

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union, Callable
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -29,12 +29,12 @@ class SearchIndexBase:
     def __init__(
         self,
         name: str,
-        key_prefix: str = "rvl",
+        prefix: str = "rvl",
         storage_type: str = "hash",
         fields: Optional[List["Field"]] = None,
     ):
         self._name = name
-        self._key_prefix = key_prefix
+        self._prefix = prefix
         self._storage = storage_type
         self._fields = fields
         self._redis_conn: Optional[redis.Redis] = None
@@ -227,7 +227,7 @@ class SearchIndexBase:
         data: Iterable[Dict[str, Any]],
         key_field: Optional[str] = None,
         preprocess: Optional[Callable] = None,
-        **kwargs
+        **kwargs,
     ):
         """Load data into Redis and index using this SearchIndex object.
 
@@ -261,11 +261,11 @@ class SearchIndex(SearchIndexBase):
     def __init__(
         self,
         name: str,
-        key_prefix: str = "rvl",
+        prefix: str = "rvl",
         storage_type: str = "hash",
         fields: Optional[List["Field"]] = None,
     ):
-        super().__init__(name, key_prefix, storage_type, fields)
+        super().__init__(name, prefix, storage_type, fields)
 
     @classmethod
     def from_existing(
@@ -296,11 +296,11 @@ class SearchIndex(SearchIndexBase):
         info = convert_bytes(client.ft(name).info())
         index_definition = make_dict(info["index_definition"])
         storage_type = index_definition["key_type"].lower()
-        key_prefix = index_definition["prefixes"][0]
+        prefix = index_definition["prefixes"][0]
         instance = cls(
             name=name,
             storage_type=storage_type,
-            key_prefix=key_prefix,
+            prefix=prefix,
             fields=fields,
         )
         instance.set_client(client)
@@ -345,7 +345,9 @@ class SearchIndex(SearchIndexBase):
         # will raise correct response error if index already exists
         self._redis_conn.ft(self._name).create_index(  # type: ignore
             fields=self._fields,
-            definition=IndexDefinition(prefix=[self._key_prefix], index_type=storage_type),
+            definition=IndexDefinition(
+                prefix=[self._prefix], index_type=storage_type
+            ),
         )
 
     @check_connected("_redis_conn")
@@ -367,7 +369,7 @@ class SearchIndex(SearchIndexBase):
         data: Iterable[Dict[str, Any]],
         key_field: Optional[str] = None,
         preprocess: Optional[Callable] = None,
-        **kwargs
+        **kwargs,
     ):
         """Load data into Redis and index using this SearchIndex object.
 
@@ -427,11 +429,11 @@ class AsyncSearchIndex(SearchIndexBase):
     def __init__(
         self,
         name: str,
-        key_prefix: str = "rvl",
+        prefix: str = "rvl",
         storage_type: str = "hash",
         fields: Optional[List["Field"]] = None,
     ):
-        super().__init__(name, key_prefix, storage_type, fields)
+        super().__init__(name, prefix, storage_type, fields)
 
     @classmethod
     async def from_existing(
@@ -462,11 +464,11 @@ class AsyncSearchIndex(SearchIndexBase):
         info = convert_bytes(await client.ft(name).info())
         index_definition = make_dict(info["index_definition"])
         storage_type = index_definition["key_type"].lower()
-        key_prefix = index_definition["prefixes"][0]
+        prefix = index_definition["prefixes"][0]
         instance = cls(
             name=name,
             storage_type=storage_type,
-            key_prefix=key_prefix,
+            prefix=prefix,
             fields=fields,
         )
         instance.set_client(client)
@@ -506,7 +508,9 @@ class AsyncSearchIndex(SearchIndexBase):
         # Create Index
         await self._redis_conn.ft(self._name).create_index(  # type: ignore
             fields=self._fields,
-            definition=IndexDefinition(prefix=[self._key_prefix], index_type=storage_type),
+            definition=IndexDefinition(
+                prefix=[self._prefix], index_type=storage_type
+            ),
         )
 
     @check_connected("_redis_conn")

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -345,9 +345,7 @@ class SearchIndex(SearchIndexBase):
         # will raise correct response error if index already exists
         self._redis_conn.ft(self._name).create_index(  # type: ignore
             fields=self._fields,
-            definition=IndexDefinition(
-                prefix=[self._prefix], index_type=storage_type
-            ),
+            definition=IndexDefinition(prefix=[self._prefix], index_type=storage_type),
         )
 
     @check_connected("_redis_conn")
@@ -508,9 +506,7 @@ class AsyncSearchIndex(SearchIndexBase):
         # Create Index
         await self._redis_conn.ft(self._name).create_index(  # type: ignore
             fields=self._fields,
-            definition=IndexDefinition(
-                prefix=[self._prefix], index_type=storage_type
-            ),
+            definition=IndexDefinition(prefix=[self._prefix], index_type=storage_type),
         )
 
     @check_connected("_redis_conn")

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -71,10 +71,13 @@ def test_search_index_load_preprocess(client):
     def preprocess(record):
         record["test"] = "foo"
         return record
-
     si.load(data, key_field="id", preprocess=preprocess)
-
     assert convert_bytes(client.hget("rvl:1", "test")) == "foo"
+
+    def bad_preprocess(record):
+        return 1
+    with pytest.raises(TypeError):
+        si.load(data, key_field="id", preprocess=bad_preprocess)
 
 
 @pytest.mark.asyncio

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -71,11 +71,13 @@ def test_search_index_load_preprocess(client):
     def preprocess(record):
         record["test"] = "foo"
         return record
+
     si.load(data, key_field="id", preprocess=preprocess)
     assert convert_bytes(client.hget("rvl:1", "test")) == "foo"
 
     def bad_preprocess(record):
         return 1
+
     with pytest.raises(TypeError):
         si.load(data, key_field="id", preprocess=bad_preprocess)
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -62,6 +62,21 @@ def test_search_index_load(client):
     assert convert_bytes(client.hget("rvl:1", "value")) == "test"
 
 
+def test_search_index_load_preprocess(client):
+    si = SearchIndex("my_index", fields=fields)
+    si.set_client(client)
+    si.create(overwrite=True)
+    data = [{"id": "1", "value": "test"}]
+
+    def preprocess(record):
+        record["test"] = "foo"
+        return record
+
+    si.load(data, key_field="id", preprocess=preprocess)
+
+    assert convert_bytes(client.hget("rvl:1", "test")) == "foo"
+
+
 @pytest.mark.asyncio
 async def test_async_search_index_creation(async_client):
     asi = AsyncSearchIndex("my_index", fields=fields)


### PR DESCRIPTION
Another finding from working the arxiv example.. often you need to unpack or edit a record before writing to the source. If you do this before invoking redisvl, you add an additional loop, one that is unnecessary in the end. So this allows devs to optionally add a preprocessor method on load to call against each record.