### PR TITLE
Add MetadataSchemaGenerator

### DIFF
--- a/redisvl/schema.py
+++ b/redisvl/schema.py
@@ -195,7 +195,9 @@ class MetadataSchemaGenerator:
             return None
         elif self._test_numeric(value):
             return "numeric"
-        elif isinstance(value, (list, set, tuple)) and all(isinstance(v, str) for v in value):
+        elif isinstance(value, (list, set, tuple)) and all(
+            isinstance(v, str) for v in value
+        ):
             return "tag"
         elif isinstance(value, str):
             return "text"
@@ -203,9 +205,7 @@ class MetadataSchemaGenerator:
             return "unknown"
 
     def generate(
-        self,
-        metadata: Dict[str, Any],
-        strict: Optional[bool] = False
+        self, metadata: Dict[str, Any], strict: Optional[bool] = False
     ) -> Dict[str, List[Dict[str, Any]]]:
         """
         Generate a schema from the provided metadata.
@@ -223,11 +223,7 @@ class MetadataSchemaGenerator:
         Raises:
             ValueError: If the force parameter is True and a field's type cannot be determined.
         """
-        result: Dict[str, List[Dict[str, Any]]] = {
-            "text": [],
-            "numeric": [],
-            "tag": []
-        }
+        result: Dict[str, List[Dict[str, Any]]] = {"text": [], "numeric": [], "tag": []}
 
         for key, value in metadata.items():
             field_type = self._infer_type(value)
@@ -246,10 +242,10 @@ class MetadataSchemaGenerator:
             field_class = {
                 "text": TextFieldSchema,
                 "tag": TagFieldSchema,
-                "numeric": NumericFieldSchema
-            }.get(field_type)
+                "numeric": NumericFieldSchema,
+            }.get(field_type)  # type: ignore
 
             if field_class:
-                result[field_type].append(field_class(name=key).dict(exclude_none=True))
+                result[field_type].append(field_class(name=key).dict(exclude_none=True))  # type: ignore
 
         return result

--- a/redisvl/schema.py
+++ b/redisvl/schema.py
@@ -244,8 +244,8 @@ class MetadataSchemaGenerator:
                 "tag": TagFieldSchema,
                 "numeric": NumericFieldSchema,
             }.get(
-                field_type
-            )  # type: ignore
+                field_type  # type: ignore
+            )
 
             if field_class:
                 result[field_type].append(field_class(name=key).dict(exclude_none=True))  # type: ignore

--- a/redisvl/schema.py
+++ b/redisvl/schema.py
@@ -243,7 +243,9 @@ class MetadataSchemaGenerator:
                 "text": TextFieldSchema,
                 "tag": TagFieldSchema,
                 "numeric": NumericFieldSchema,
-            }.get(field_type)  # type: ignore
+            }.get(
+                field_type
+            )  # type: ignore
 
             if field_class:
                 result[field_type].append(field_class(name=key).dict(exclude_none=True))  # type: ignore

--- a/tests/integration/test_vectorizers.py
+++ b/tests/integration/test_vectorizers.py
@@ -12,7 +12,8 @@ from redisvl.vectorize.text import (
 @pytest.fixture
 def skip_vectorizer() -> bool:
     # os.getenv returns a string
-    return os.getenv("SKIP_VECTORIZERS", 'False').lower() == 'true'
+    return os.getenv("SKIP_VECTORIZERS", "False").lower() == "true"
+
 
 skip_vectorizer_test = lambda: pytest.config.getfixturevalue("skip_vectorizer")
 


### PR DESCRIPTION
The MetadataSchemaGenerator is responsible for taking a dictionary of key/values, inferring types, and converting to a dictionary of redisvl metadata schema objects.

- This will be useful for users looking to construct redis schema from their metadata.
- This will be useful for our integrations with LangChain and LlamaIndex.