### PR TITLE
Improve SemanticCache for metadata persistence

### DIFF
--- a/docs/api/cache.rst
+++ b/docs/api/cache.rst
@@ -15,9 +15,10 @@ SemanticCache
     SemanticCache.__init__
     SemanticCache.check
     SemanticCache.store
-    SemanticCache.set_threshold
+    SemanticCache.clear
+    SemanticCache.delete
     SemanticCache.distance_threshold
-    SemanticCache.index
+    SemanticCache.set_threshold
     SemanticCache.ttl
     SemanticCache.set_ttl
 

--- a/docs/user_guide/llmcache_03.ipynb
+++ b/docs/user_guide/llmcache_03.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Initializing and using ``SemanticCache``\n",
+    "## Initializing ``SemanticCache``\n",
     "\n",
     "``SemanticCache`` will automatically create an index within Redis upon initialization for the semantic cache content."
    ]
@@ -80,9 +80,9 @@
     "\n",
     "llmcache = SemanticCache(\n",
     "    name=\"llmcache\",                     # underlying search index name\n",
-    "    prefix=\"llmcache\",                   # redis key prefix\n",
+    "    prefix=\"llmcache\",                   # redis key prefix for hash entries\n",
     "    redis_url=\"redis://localhost:6379\",  # redis connection url string\n",
-    "    distance_threshold=0.1               # semantic distance threshold\n",
+    "    distance_threshold=0.1               # semantic cache distance threshold\n",
     ")"
    ]
   },
@@ -120,6 +120,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic Cache Usage"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
@@ -134,19 +141,27 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Empty cache\n"
+     ]
     }
    ],
    "source": [
-    "# Check the cache -- should be empty\n",
-    "llmcache.check(prompt=question)"
+    "# Check the semantic cache -- should be empty\n",
+    "if response := llmcache.check(prompt=question):\n",
+    "    print(response)\n",
+    "else:\n",
+    "    print(\"Empty cache\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our initial cache check should be empty since we have not yet stored anything in the cache. Below, store the `question`,\n",
+    "proper `response`, and any arbitrary `metadata` (as a python dictionary object) in the cache."
    ]
   },
   {
@@ -155,8 +170,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Cache the question and answer\n",
-    "llmcache.store(prompt=question, response=\"Paris\")"
+    "# Cache the question, answer, and arbitrary metadata\n",
+    "llmcache.store(\n",
+    "    prompt=question,\n",
+    "    response=\"Paris\",\n",
+    "    metadata={\"city\": \"Paris\", \"country\": \"france\"}\n",
+    ")"
    ]
   },
   {
@@ -165,19 +184,19 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[{'response': 'Paris', 'vector_distance': '8.34465026855e-07'}]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'id': 'llmcache:115049a298532be2f181edb03f766770c0db84c22aff39003fec340deaec7545', 'vector_distance': '8.34465026855e-07', 'prompt': 'What is the capital of France?', 'response': 'Paris', 'metadata': {'city': 'Paris', 'country': 'france'}}]\n"
+     ]
     }
    ],
    "source": [
-    "# Check the cache again to see if new answer is there\n",
-    "llmcache.check(prompt=question)"
+    "# Check the cache again\n",
+    "if response := llmcache.check(prompt=question, return_fields=[\"prompt\", \"response\", \"metadata\"]):\n",
+    "    print(response)\n",
+    "else:\n",
+    "    print(\"Empty cache\")"
    ]
   },
   {
@@ -188,9 +207,7 @@
     {
      "data": {
       "text/plain": [
-       "[{'response': 'Paris',\n",
-       "  'prompt': 'What is the capital of France?',\n",
-       "  'vector_distance': '8.34465026855e-07'}]"
+       "'Paris'"
       ]
      },
      "execution_count": 9,
@@ -199,39 +216,42 @@
     }
    ],
    "source": [
-    "# Update the return fields to gather other kinds of information about the cached entity\n",
-    "llmcache.check(prompt=question, return_fields=[\"response\", \"prompt\"])"
+    "# Check for a semantically similar result\n",
+    "question = \"What actually is the capital of France?\"\n",
+    "llmcache.check(prompt=question)[0]['response']"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'response': 'Paris', 'vector_distance': '0.0988066792488'}]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Check for a semantically similar result\n",
-    "llmcache.check(prompt=\"What actually is the capital of France?\")"
+    "# Widen the semantic distance threshold\n",
+    "llmcache.set_threshold(0.3)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Paris'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Widen the semantic distance threshold\n",
-    "llmcache.set_threshold(0.3)"
+    "# Really try to trick it by asking around the point\n",
+    "# But is able to slip just under our new threshold\n",
+    "question = \"What is the capital city of the country in Europe that also has a city named Nice?\"\n",
+    "llmcache.check(prompt=question)[0]['response']"
    ]
   },
   {
@@ -242,7 +262,7 @@
     {
      "data": {
       "text/plain": [
-       "[{'response': 'Paris', 'vector_distance': '0.273138523102'}]"
+       "[]"
       ]
      },
      "execution_count": 12,
@@ -251,40 +271,9 @@
     }
    ],
    "source": [
-    "# Really try to trick it by asking around the point\n",
-    "# But is able to slip just under our new threshold\n",
-    "llmcache.check(\n",
-    "    prompt=\"What is the capital city of the country in Europe that also has a city named Nice?\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Invalidate the cache completely by clearing it out\n",
-    "llmcache.clear()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
+    "llmcache.clear()\n",
+    "\n",
     "# should be empty now\n",
     "llmcache.check(prompt=question)"
    ]
@@ -300,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,14 +316,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Without caching, a call to openAI to answer this simple question took 0.5083951950073242 seconds.\n"
+      "Without caching, a call to openAI to answer this simple question took 0.5017588138580322 seconds.\n"
      ]
     }
    ],
@@ -349,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,15 +347,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time Taken with cache enabled: 0.08954691886901855\n",
-      "Percentage of time saved: 82.39%\n"
+      "Time Taken with cache enabled: 0.327639102935791\n",
+      "Percentage of time saved: 34.7%\n"
      ]
     }
    ],
@@ -380,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -398,7 +387,7 @@
       "│ num_records                 │ 16          │\n",
       "│ percent_indexed             │ 1           │\n",
       "│ hash_indexing_failures      │ 0           │\n",
-      "│ number_of_uses              │ 26          │\n",
+      "│ number_of_uses              │ 9           │\n",
       "│ bytes_per_record_avg        │ 5.25        │\n",
       "│ doc_table_size_mb           │ 0.000134468 │\n",
       "│ inverted_sz_mb              │ 8.01086e-05 │\n",
@@ -408,7 +397,7 @@
       "│ offsets_per_term_avg        │ 0.875       │\n",
       "│ records_per_doc_avg         │ 16          │\n",
       "│ sortable_values_size_mb     │ 0           │\n",
-      "│ total_indexing_time         │ 0.76        │\n",
+      "│ total_indexing_time         │ 0.548       │\n",
       "│ total_inverted_index_blocks │ 7           │\n",
       "│ vector_index_sz_mb          │ 3.0161      │\n",
       "╰─────────────────────────────┴─────────────╯\n"
@@ -422,15 +411,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Clear the cache\n",
-    "llmcache.clear()\n",
-    "\n",
-    "# Remove the underlying index\n",
-    "llmcache._index.delete(drop=True)"
+    "# Clear the cache AND delete the underlying index\n",
+    "llmcache.delete()"
    ]
   }
  ],

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -235,13 +235,13 @@ class SearchIndex:
             connection_args (Dict[str, Any], optional): Redis client connection
                 args.
 
+        Returns:
+            SearchIndex: A RedisVL SearchIndex object.
+
         Example:
             from redisvl.index import SearchIndex
             index = SearchIndex.from_yaml("schema.yaml", redis_url="redis://localhost:6379")
             index.create(overwrite=True)
-
-        Returns:
-            SearchIndex: A RedisVL SearchIndex object.
         """
         schema = IndexSchema.from_yaml(schema_path)
         return cls(schema=schema, connection_args=connection_args, **kwargs)
@@ -257,6 +257,9 @@ class SearchIndex:
             connection_args (Dict[str, Any], optional): Redis client connection
                 args.
 
+        Returns:
+            SearchIndex: A RedisVL SearchIndex object.
+
         Example:
             from redisvl.index import SearchIndex
             index = SearchIndex.from_dict({
@@ -270,9 +273,6 @@ class SearchIndex:
                 }
             }, redis_url="redis://localhost:6379")
             index.create(overwrite=True)
-
-        Returns:
-            SearchIndex: A RedisVL SearchIndex object.
         """
         schema = IndexSchema.from_dict(schema_dict)
         return cls(schema=schema, connection_args=connection_args, **kwargs)
@@ -298,17 +298,17 @@ class SearchIndex:
             use_async (bool): If `True`, establishes a connection with an async
                 Redis client. Defaults to `False`.
 
-        Example:
-            # standard sync Redis connection
-            index.connect(redis_url="redis://localhost:6379")
-            # async Redis connection
-            index.connect(redis_url="redis://localhost:6379", use_async=True)
-
         Raises:
             redis.exceptions.ConnectionError: If the connection to the Redis
                 server fails.
             ValueError: If the Redis URL is not provided nor accessible
                 through the `REDIS_URL` environment variable.
+
+        Example:
+            # standard sync Redis connection
+            index.connect(redis_url="redis://localhost:6379")
+            # async Redis connection
+            index.connect(redis_url="redis://localhost:6379", use_async=True)
         """
         self._redis_conn.connect(redis_url, use_async, **kwargs)
         return self
@@ -329,17 +329,20 @@ class SearchIndex:
             client (Union[redis.Redis, aredis.Redis]): A Redis or Async Redis
                 client instance to be used for the connection.
 
-        Example:
-            import redis
-            r = redis.Redis.from_url("redis://localhost:6379")
-            index.set_client(r)
-            # async Redis client
-            import redis.asyncio as aredis
-            r = aredis.Redis.from_url("redis://localhost:6379")
-            index.set_client(r)
-
         Raises:
             TypeError: If the provided client is not valid.
+
+        Example:
+            import redis
+
+            r = redis.Redis.from_url("redis://localhost:6379")
+            index.set_client(r)
+
+            # async Redis client
+            import redis.asyncio as aredis
+
+            r = aredis.Redis.from_url("redis://localhost:6379")
+            index.set_client(r)
         """
         self._redis_conn.set_client(client)
         return self

--- a/redisvl/llmcache/base.py
+++ b/redisvl/llmcache/base.py
@@ -1,27 +1,24 @@
 import hashlib
 import json
-
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional
 
 
 class BaseLLMCache:
-    _ttl: Optional[int] = None
+    def __init__(self, ttl: Optional[int] = None):
+        self._ttl: Optional[int] = None
+        self.set_ttl(ttl)
 
     @property
     def ttl(self) -> Optional[int]:
-        """Returns the TTL for the cache.
-
-        Returns:
-            Optional[int]: The TTL for the cache.
-        """
+        """The default TTL, in seconds, for entries in the cache."""
         return self._ttl
 
     def set_ttl(self, ttl: Optional[int] = None):
-        """Sets the TTL for the cache.
+        """Set the default TTL, in seconds, for entries in the cache.
 
         Args:
             ttl (Optional[int], optional): The optional time-to-live expiration
-                for the cache.
+                for the cache, in seconds.
 
         Raises:
             ValueError: If the time-to-live value is not an integer.
@@ -41,7 +38,6 @@ class BaseLLMCache:
         vector: Optional[List[float]] = None,
         num_results: int = 1,
         return_fields: Optional[List[str]] = None,
-        **kwargs,
     ) -> List[dict]:
         raise NotImplementedError
 
@@ -51,7 +47,7 @@ class BaseLLMCache:
         response: str,
         vector: Optional[List[float]] = None,
         metadata: Optional[dict] = {},
-    ) -> None:
+    ) -> str:
         """Stores the specified key-value pair in the cache along
         with metadata."""
         raise NotImplementedError
@@ -61,7 +57,9 @@ class BaseLLMCache:
         return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
 
     def serialize(self, metadata: Dict[str, Any]) -> str:
+        """Serlize the input into a string."""
         return json.dumps(metadata)
 
     def deserialize(self, metadata: str) -> Dict[str, Any]:
+        """Deserialize the input from a string."""
         return json.loads(metadata)

--- a/redisvl/llmcache/base.py
+++ b/redisvl/llmcache/base.py
@@ -1,7 +1,7 @@
 import hashlib
-from typing import List, Optional
+import json
 
-from redisvl.index import SearchIndex
+from typing import List, Optional, Dict, Any
 
 
 class BaseLLMCache:
@@ -59,3 +59,9 @@ class BaseLLMCache:
     def hash_input(self, prompt: str):
         """Hashes the input using SHA256."""
         return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    def serialize(self, metadata: Dict[str, Any]) -> str:
+        return json.dumps(metadata)
+
+    def deserialize(self, metadata: str) -> Dict[str, Any]:
+        return json.loads(metadata)

--- a/tests/integration/test_llmcache.py
+++ b/tests/integration/test_llmcache.py
@@ -37,7 +37,9 @@ def test_store_and_check(cache, vectorizer):
     check_result = cache.check(vector=vector)
 
     assert len(check_result) == 1
+    print(check_result, flush=True)
     assert response == check_result[0]["response"]
+    assert "metadata" not in check_result[0]
 
 
 # Test clearing the cache
@@ -90,11 +92,13 @@ def test_store_with_metadata(cache, vectorizer):
     vector = vectorizer.embed(prompt)
 
     cache.store(prompt, response, vector=vector, metadata=metadata)
-    check_result = cache.check(vector=vector, return_fields=["source", "response"])
+    check_result = cache.check(vector=vector, num_results=1)
 
     assert len(check_result) == 1
-    assert response == check_result[0]["response"]
-    assert check_result[0]["source"] == "test"
+    print(check_result, flush=True)
+    assert check_result[0]["response"] == response
+    assert check_result[0]["metadata"] == metadata
+    assert check_result[0]["prompt"] == prompt
 
 
 # Test setting and getting the distance threshold
@@ -123,4 +127,6 @@ def test_multiple_items(cache, vectorizer):
         vector = vectorizer.embed(prompt)
         check_result = cache.check(vector=vector)
         assert len(check_result) == 1
+        print(check_result, flush=True)
         assert check_result[0]["response"] == expected_response
+        assert "metadata" not in check_result[0]


### PR DESCRIPTION
This PR improves the ability to store optional metadata alongside entries in the `SemanticCache`. It also improves documentation, docstrings, comments, and user guide examples for the cache.