### PR TITLE
Upgrade to use Pydantic 2.x.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ scratch
 *.csv
 wiki_schema.yaml
 docs/_build/
+.venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,39 @@ Here's how to get started with your code contribution:
 ### Dev Environment
 There is a provided `requirements.txt` and `requirements-dev.txt` file you can use to install required libraries with `pip` into your virtual environment.
 
+Or use the local package editable install method:
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[all,dev]
+```
+
+Then to deactivate the env:
+```
+source deactivate
+```
+
+### Linting and Tests
+
+Formatting and linting checks:
+```bash
+make format
+make sort-imports
+make mypy
+```
+
+Tests with vectorizers:
+```bash
+make test-cov
+```
+
+Tests w/out vectorizers:
+```bash
+SKIP_VECTORIZERS=true make test-cov
+```
+
+> Dev requirements are needed here to be able to run tests and linting.
+
 ### Docker Tips
 
 Make sure to have [Redis](https://redis.io) accessible with Search & Query features enabled on [Redis Cloud](https://redis.com/try-free) or locally in docker with [Redis Stack](https://redis.io/docs/getting-started/install-stack/docker/):
@@ -38,7 +71,7 @@ Make sure to have [Redis](https://redis.io) accessible with Search & Query featu
 docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
 ```
 
-This will also spin up the [Redis Insight GUI](https://redis.com/redis-enterprise/redis-insight/) at `http://localhost:8001`.
+This will also spin up the [FREE RedisInsight GUI](https://redis.com/redis-enterprise/redis-insight/) at `http://localhost:8001`.
 
 ## How to Report a Bug
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,12 @@ source deactivate
 
 ### Linting and Tests
 
-Formatting and linting checks:
+Check formatting, linting, and typing:
 ```bash
-make format
-make sort-imports
-make mypy
+make check
 ```
 
-Tests with vectorizers:
+Tests (with vectorizers):
 ```bash
 make test-cov
 ```
@@ -62,6 +60,7 @@ SKIP_VECTORIZERS=true make test-cov
 ```
 
 > Dev requirements are needed here to be able to run tests and linting.
+> See other commands in the [Makefile](Makefile)
 
 ### Docker Tips
 

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -196,8 +196,7 @@ class SearchIndex:
         self.schema = schema
 
         self._storage = self._STORAGE_MAP[self.schema.storage_type](
-            prefix=self.schema.prefix,
-            key_separator=self.schema.key_separator
+            prefix=self.schema.prefix, key_separator=self.schema.key_separator
         )
 
     @property

--- a/redisvl/index.py
+++ b/redisvl/index.py
@@ -196,7 +196,8 @@ class SearchIndex:
         self.schema = schema
 
         self._storage = self._STORAGE_MAP[self.schema.storage_type](
-            self.schema.prefix, self.schema.key_separator
+            prefix=self.schema.prefix,
+            key_separator=self.schema.key_separator
         )
 
     @property

--- a/redisvl/llmcache/semantic.py
+++ b/redisvl/llmcache/semantic.py
@@ -67,7 +67,7 @@ class SemanticCache(BaseLLMCache):
         distance_threshold: float = 0.1,
         ttl: Optional[int] = None,
         vectorizer: BaseVectorizer = HFTextVectorizer(
-            "sentence-transformers/all-mpnet-base-v2"
+            model="sentence-transformers/all-mpnet-base-v2"
         ),
         redis_url: str = "redis://localhost:6379",
         connection_args: Dict[str, Any] = {},

--- a/redisvl/schema/fields.py
+++ b/redisvl/schema/fields.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional, Union
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 from redis.commands.search.field import Field as RedisField
 from redis.commands.search.field import GeoField as RedisGeoField
 from redis.commands.search.field import NumericField as RedisNumericField
@@ -68,7 +68,8 @@ class BaseVectorField(BaseModel):
     initial_cap: Optional[int] = None
     as_name: Optional[str] = None
 
-    @validator("algorithm", "datatype", "distance_metric", pre=True)
+    @field_validator("algorithm", "datatype", "distance_metric", mode="before")
+    @classmethod
     def uppercase_strings(cls, v):
         return v.upper()
 

--- a/redisvl/schema/fields.py
+++ b/redisvl/schema/fields.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional, Union
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic.v1 import BaseModel, Field, validator
 from redis.commands.search.field import Field as RedisField
 from redis.commands.search.field import GeoField as RedisGeoField
 from redis.commands.search.field import NumericField as RedisNumericField
@@ -68,7 +68,7 @@ class BaseVectorField(BaseModel):
     initial_cap: Optional[int] = None
     as_name: Optional[str] = None
 
-    @field_validator("algorithm", "datatype", "distance_metric", mode="before")
+    @validator("algorithm", "datatype", "distance_metric", pre=True)
     @classmethod
     def uppercase_strings(cls, v):
         return v.upper()

--- a/redisvl/schema/schema.py
+++ b/redisvl/schema/schema.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Union
 
 import yaml
-from pydantic import BaseModel, field_validator
+from pydantic.v1 import BaseModel, validator
 from redis.commands.search.field import Field as RedisField
 
 from redisvl.schema.fields import BaseField, BaseVectorField, FieldFactory
@@ -65,7 +65,7 @@ class IndexSchema(BaseModel):
     storage_type: StorageType = StorageType.HASH
     fields: Dict[str, List[Union[BaseField, BaseVectorField]]] = {}
 
-    @field_validator("fields", mode="before")
+    @validator("fields", pre=True)
     @classmethod
     def check_unique_field_names(cls, fields):
         """Validate that field names are all unique."""

--- a/redisvl/schema/schema.py
+++ b/redisvl/schema/schema.py
@@ -242,7 +242,7 @@ class IndexSchema(BaseModel):
                     field_name,
                 )
                 fields.setdefault(field_type, []).append(
-                    new_field.model_dump(exclude_unset=True)
+                    new_field.dict(exclude_unset=True)
                 )
             except ValueError as e:
                 if strict:
@@ -301,7 +301,7 @@ class IndexSchema(BaseModel):
         formatted_fields = {}
         for field_type, fields in self.fields.items():
             formatted_fields[field_type] = [
-                field.model_dump(exclude_unset=True) for field in fields
+                field.dict(exclude_unset=True) for field in fields
             ]
         return {"index": index_data, "fields": formatted_fields}
 

--- a/redisvl/storage.py
+++ b/redisvl/storage.py
@@ -1,8 +1,8 @@
 import asyncio
 import uuid
-from pydantic import BaseModel
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
+from pydantic import BaseModel
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
 from redis.commands.search.indexDefinition import IndexType
@@ -17,6 +17,7 @@ class BaseStorage(BaseModel):
     Provides foundational methods for key management, data preprocessing,
     validation, and basic read/write operations (both sync and async).
     """
+
     type: IndexType  # Type of index used in storage
     prefix: str  # Prefix for Redis keys
     key_separator: str  # Separator between prefix and key value
@@ -381,6 +382,7 @@ class HashStorage(BaseStorage):
     Implements hash-specific logic for validation and read/write operations
     (both sync and async) in Redis.
     """
+
     type: IndexType = IndexType.HASH
 
     def _validate(self, obj: Dict[str, Any]):
@@ -452,6 +454,7 @@ class JsonStorage(BaseStorage):
     Implements json-specific logic for validation and read/write operations
     (both sync and async) in Redis.
     """
+
     type: IndexType = IndexType.JSON
 
     def _validate(self, obj: Dict[str, Any]):

--- a/redisvl/storage.py
+++ b/redisvl/storage.py
@@ -2,7 +2,7 @@ import asyncio
 import uuid
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
 from redis.commands.search.indexDefinition import IndexType

--- a/redisvl/vectorize/base.py
+++ b/redisvl/vectorize/base.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel, validator
+from typing import Any, Callable, List, Optional
 
-from typing import Callable, List, Optional, Any
+from pydantic import BaseModel, validator
 
 from redisvl.utils.utils import array_to_buffer
 
@@ -10,7 +10,7 @@ class BaseVectorizer(BaseModel):
     dims: int
     client: Any
 
-    @validator('dims')
+    @validator("dims")
     def check_dims(cls, v):
         if v <= 0:
             raise ValueError("Dimension must be a positive integer")

--- a/redisvl/vectorize/base.py
+++ b/redisvl/vectorize/base.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, List, Optional
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 from redisvl.utils.utils import array_to_buffer
 
@@ -10,7 +10,8 @@ class BaseVectorizer(BaseModel):
     dims: int
     client: Any
 
-    @validator("dims")
+    @field_validator("dims", mode="before")
+    @classmethod
     def check_dims(cls, v):
         if v <= 0:
             raise ValueError("Dimension must be a positive integer")

--- a/redisvl/vectorize/base.py
+++ b/redisvl/vectorize/base.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, List, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic.v1 import BaseModel, validator
 
 from redisvl.utils.utils import array_to_buffer
 
@@ -10,7 +10,7 @@ class BaseVectorizer(BaseModel):
     dims: int
     client: Any
 
-    @field_validator("dims", mode="before")
+    @validator("dims", pre=True)
     @classmethod
     def check_dims(cls, v):
         if v <= 0:

--- a/redisvl/vectorize/base.py
+++ b/redisvl/vectorize/base.py
@@ -1,26 +1,20 @@
-from typing import Callable, List, Optional
+from pydantic import BaseModel, validator
+
+from typing import Callable, List, Optional, Any
 
 from redisvl.utils.utils import array_to_buffer
 
 
-class BaseVectorizer:
-    _dims = None
+class BaseVectorizer(BaseModel):
+    model: str
+    dims: int
+    client: Any
 
-    def __init__(self, model: str):
-        self._model = model
-
-    @property
-    def model(self) -> str:
-        return self._model
-
-    @property
-    def dims(self) -> Optional[int]:
-        return self._dims
-
-    def set_model(self, model: str, dims: Optional[int] = None) -> None:
-        self._model = model
-        if dims is not None:
-            self._dims = dims
+    @validator('dims')
+    def check_dims(cls, v):
+        if v <= 0:
+            raise ValueError("Dimension must be a positive integer")
+        return v
 
     def embed_many(
         self,

--- a/redisvl/vectorize/text/openai.py
+++ b/redisvl/vectorize/text/openai.py
@@ -41,6 +41,7 @@ class OpenAITextVectorizer(BaseVectorizer):
         )
 
     """
+
     def __init__(
         self, model: str = "text-embedding-ada-002", api_config: Optional[Dict] = None
     ):
@@ -84,9 +85,9 @@ class OpenAITextVectorizer(BaseVectorizer):
     @staticmethod
     def _set_model_dims(client) -> int:
         try:
-            embedding = client.create(
-                input=["dimension test"], engine=self.model
-            )["data"][0]["embedding"]
+            embedding = client.create(input=["dimension test"], engine=self.model)[
+                "data"
+            ][0]["embedding"]
         except (KeyError, IndexError) as ke:
             raise ValueError(f"Unexpected response from the OpenAI API: {str(ke)}")
         except Exception as e:  # pylint: disable=broad-except

--- a/redisvl/vectorize/text/openai.py
+++ b/redisvl/vectorize/text/openai.py
@@ -79,15 +79,15 @@ class OpenAITextVectorizer(BaseVectorizer):
 
         openai.api_key = api_key
         client = openai.Embedding
-        dims = self._set_model_dims(client)
+        dims = self._set_model_dims(client, model)
         super().__init__(model=model, dims=dims, client=client)
 
     @staticmethod
-    def _set_model_dims(client) -> int:
+    def _set_model_dims(client, model) -> int:
         try:
-            embedding = client.create(input=["dimension test"], engine=self.model)[
-                "data"
-            ][0]["embedding"]
+            embedding = client.create(input=["dimension test"], engine=model)["data"][
+                0
+            ]["embedding"]
         except (KeyError, IndexError) as ke:
             raise ValueError(f"Unexpected response from the OpenAI API: {str(ke)}")
         except Exception as e:  # pylint: disable=broad-except

--- a/redisvl/vectorize/text/vertexai.py
+++ b/redisvl/vectorize/text/vertexai.py
@@ -41,6 +41,7 @@ class VertexAITextVectorizer(BaseVectorizer):
         )
 
     """
+
     def __init__(
         self, model: str = "textembedding-gecko", api_config: Optional[Dict] = None
     ):
@@ -109,7 +110,7 @@ class VertexAITextVectorizer(BaseVectorizer):
 
     def _set_model_dims(client) -> int:
         try:
-            embedding = self.client.get_embeddings(["dimension test"])[0].values
+            embedding = client.get_embeddings(["dimension test"])[0].values
         except (KeyError, IndexError) as ke:
             raise ValueError(f"Unexpected response from the VertexAI API: {str(ke)}")
         except Exception as e:  # pylint: disable=broad-except

--- a/redisvl/vectorize/text/vertexai.py
+++ b/redisvl/vectorize/text/vertexai.py
@@ -105,9 +105,10 @@ class VertexAITextVectorizer(BaseVectorizer):
             )
 
         client = TextEmbeddingModel.from_pretrained(model)
-        dims = self._set_model_dims()
+        dims = self._set_model_dims(client)
         super().__init__(model=model, dims=dims, client=client)
 
+    @staticmethod
     def _set_model_dims(client) -> int:
         try:
             embedding = client.get_embeddings(["dimension test"])[0].values

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 redis>=5.0.0
 pyyaml
 coloredlogs
-pydantic<2.0.0
+pydantic>=2.0.0
 tenacity==8.2.2
 tabulate==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 pyyaml
 coloredlogs
 redis>=5.0.0
-pydantic==2.5.3
+pydantic>=2,<3
 tenacity==8.2.2
 tabulate==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
-redis>=5.0.0
 pyyaml
 coloredlogs
-pydantic>=2.0.0
+redis>=5.0.0
+pydantic==2.5.3
 tenacity==8.2.2
 tabulate==0.9.0

--- a/tests/unit/test_fields.py
+++ b/tests/unit/test_fields.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import ValidationError
+
 from redis.commands.search.field import GeoField as RedisGeoField
 from redis.commands.search.field import NumericField as RedisNumericField
 from redis.commands.search.field import TagField as RedisTagField
@@ -7,7 +7,6 @@ from redis.commands.search.field import TextField as RedisTextField
 from redis.commands.search.field import VectorField as RedisVectorField
 
 from redisvl.schema.fields import (
-    BaseField,
     FieldFactory,
     FlatVectorField,
     GeoField,

--- a/tests/unit/test_fields.py
+++ b/tests/unit/test_fields.py
@@ -1,5 +1,4 @@
 import pytest
-
 from redis.commands.search.field import GeoField as RedisGeoField
 from redis.commands.search.field import NumericField as RedisNumericField
 from redis.commands.search.field import TagField as RedisTagField

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -26,7 +26,7 @@ def test_create_key(storage_instance):
     key_field = "id"
     obj = {key_field: "1234"}
     expected_key = (
-        f"{storage_instance._prefix}{storage_instance._key_separator}{obj[key_field]}"
+        f"{storage_instance.prefix}{storage_instance.key_separator}{obj[key_field]}"
     )
     generated_key = storage_instance._create_key(obj, key_field)
     assert (


### PR DESCRIPTION
With the shift in the ecosystem to Pydantic 2.x.x, we need to get `redisvl` to the same level.

Referenced here: https://github.com/RedisVentures/redisvl/issues/86

Fortunately, there is not a ton of complex usage of Pydantic; which makes this easy! Changes include:

- Shifting the storage classes to use Pydantic to avoid manual (and ugly) field validation. Now, the subclasses inherit from the base and params are all typed as expected.
- Shifting the vectorizer classes to use Pydantic for the same reasons.
- Bump and pin pydantic version in the packge requirements to a reasonable range `pydantic>=2.0.0,<3`
- use `v1` shim for now for safety