### PR TITLE
Changes to contributions page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Or use the local package editable install method:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e .[all,dev]
+pip install -e '.[all,dev]'
 ```
 
 Then to deactivate the env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ Tests (with vectorizers):
 make test-cov
 ```
 
+**NOTE**: Some tests require the `REDIS_URL` environment variable to be set (e.g. `export REDIS_URL=redis://localhost:6379`).
+
 Tests w/out vectorizers:
 ```bash
 SKIP_VECTORIZERS=true make test-cov


### PR DESCRIPTION
- Highlight the need for `REDIS_URL` env var
- Add quotes around `pip install -e` for compatibility with all shells