### PR TITLE
Update and pin package dependency ranges

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pyyaml
 coloredlogs
 redis>=5.0.0
 pydantic>=2,<3
-tenacity==8.2.2
-tabulate==0.9.0
+tenacity>=8.2.2
+tabulate>=0.9.0,<1


### PR DESCRIPTION
Loosen restriction on `tenacity` and `tabulate` to make it easier to integrate.