### PR TITLE
fix connection pool for SSL

### DIFF
--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -1,10 +1,15 @@
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
-from redis import Connection, ConnectionPool, Redis, SSLConnection
-from redis.asyncio import Connection as AConnection
+from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
 from redis.asyncio import SSLConnection as ASSLConnection
+from redis.connection import (
+    AbstractConnection,
+    Connection,
+    ConnectionPool,
+    SSLConnection,
+)
 
 from redisvl.redis.constants import REDIS_REQUIRED_MODULES
 from redisvl.redis.utils import convert_bytes
@@ -133,7 +138,7 @@ class RedisConnectionFactory:
             ValueError: If required Redis modules are not installed.
         """
         # pick the right connection class
-        connection_class = Connection
+        connection_class: Type[AbstractConnection] = Connection
         if isinstance(client.connection_pool.connection_class, ASSLConnection):
             connection_class = SSLConnection
         # set up a temp sync client

--- a/redisvl/redis/connection.py
+++ b/redisvl/redis/connection.py
@@ -138,9 +138,11 @@ class RedisConnectionFactory:
             ValueError: If required Redis modules are not installed.
         """
         # pick the right connection class
-        connection_class: Type[AbstractConnection] = Connection
-        if isinstance(client.connection_pool.connection_class, ASSLConnection):
-            connection_class = SSLConnection
+        connection_class: Type[AbstractConnection] = (
+            SSLConnection
+            if client.connection_pool.connection_class == ASSLConnection
+            else Connection
+        )
         # set up a temp sync client
         temp_client = Redis(
             connection_pool=ConnectionPool(

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -51,4 +51,8 @@ def test_unknown_redis():
 
 def test_required_modules(client):
     RedisConnectionFactory.validate_redis_modules(client)
-    RedisConnectionFactory.validate_async_redis_modules(client)
+
+
+@pytest.mark.asyncio
+async def test_async_required_modules(async_client):
+    RedisConnectionFactory.validate_async_redis_modules(async_client)


### PR DESCRIPTION
When an Async Redis SSLConnection (ACRE for example) is used, the method to check modules was failing. The module check has to be done with a sync connection because it is a decorator around certain `SearchIndex` methods.