### PR TITLE
corrects typos in overview and getting started examples

### DIFF
--- a/docs/overview/cli.ipynb
+++ b/docs/overview/cli.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "# Index\n",
     "\n",
-    "The ``rvl index`` command is can be used for a number of tasks related to creating and managing indices. Wether you are working in Python or another language, this cli tool can still be useful for managing and inspecting your indices.\n",
+    "The ``rvl index`` command can be used for a number of tasks related to creating and managing indices. Wether you are working in Python or another language, this cli tool can still be useful for managing and inspecting your indices.\n",
     "\n",
     "First, we will create an index from a yaml schema that looks like the following:\n"
    ]

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -69,7 +69,7 @@ capability enabled when creating your database.
 
 ### Redis Stack (local development)
 
-For local development and testing, Redis-Stack and be used. We recommend running Redis
+For local development and testing, Redis-Stack can be used. We recommend running Redis
 in a docker container. To do so, run the following command:
 
 ```bash

--- a/docs/user_guide/getting_started_01.ipynb
+++ b/docs/user_guide/getting_started_01.ipynb
@@ -55,7 +55,7 @@
     "fields:\n",
     "    - name: user\n",
     "      type: tag\n",
-    "    - name: credit_store\n",
+    "    - name: credit_score\n",
     "      type: tag\n",
     "    - name: job\n",
     "      type: text\n",
@@ -204,7 +204,7 @@
    "source": [
     "### Bring your own Redis connection instance\n",
     "\n",
-    "This ideal in scenarious where you have custom settings on the connection instance or if your application will share a connection pool:"
+    "This is ideal in scenarios where you have custom settings on the connection instance or if your application will share a connection pool:"
    ]
   },
   {
@@ -570,7 +570,7 @@
     "        \"attrs\": {\n",
     "            \"dims\": 3,\n",
     "            \"distance_metric\": \"cosine\",\n",
-    "            \"algorithm\": \"flat\",\n",
+    "            \"algorithm\": \"hnsw\",\n",
     "            \"datatype\": \"float32\"\n",
     "        }\n",
     "    }\n",


### PR DESCRIPTION
This address a few minor typos I came across while working through the examples.